### PR TITLE
macapp: add support for app relaunching itself

### DIFF
--- a/macapp/App/Sources/App/Dependencies/DeviceClient/DeviceClient+MacOsUsers.swift
+++ b/macapp/App/Sources/App/Dependencies/DeviceClient/DeviceClient+MacOsUsers.swift
@@ -59,7 +59,7 @@ extension DeviceClient {
       proc.waitUntilExit()
 
       let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      if let string = String(data: data, encoding: String.Encoding.utf8) {
+      if let string = String(data: data, encoding: .utf8) {
         return string.contains("(admin)") ? true : false
       } else {
         throw GetUserTypeError.stringDecodeError

--- a/macapp/App/Sources/ClientInterfaces/AppClient.swift
+++ b/macapp/App/Sources/ClientInterfaces/AppClient.swift
@@ -17,6 +17,7 @@ public struct AppClient: Sendable {
   public var installLocation: @Sendable () -> URL
   public var installedVersion: @Sendable () -> String?
   public var quit: @Sendable () async -> Void
+  public var relaunch: @Sendable () async throws -> Void
 
   public init(
     colorScheme: @escaping @Sendable () -> ColorScheme,
@@ -26,7 +27,8 @@ public struct AppClient: Sendable {
     isLaunchAtLoginEnabled: @escaping @Sendable () async -> Bool,
     installLocation: @escaping @Sendable () -> URL,
     installedVersion: @escaping @Sendable () -> String?,
-    quit: @escaping @Sendable () async -> Void
+    quit: @escaping @Sendable () async -> Void,
+    relaunch: @escaping @Sendable () async throws -> Void
   ) {
     self.colorScheme = colorScheme
     self.colorSchemeChanges = colorSchemeChanges
@@ -36,6 +38,7 @@ public struct AppClient: Sendable {
     self.installLocation = installLocation
     self.installedVersion = installedVersion
     self.quit = quit
+    self.relaunch = relaunch
   }
 }
 
@@ -66,7 +69,8 @@ extension AppClient: TestDependencyKey {
     isLaunchAtLoginEnabled: unimplemented("AppClient.isLaunchAtLoginEnabled"),
     installLocation: unimplemented("AppClient.installLocation"),
     installedVersion: unimplemented("AppClient.installedVersion"),
-    quit: unimplemented("AppClient.quit")
+    quit: unimplemented("AppClient.quit"),
+    relaunch: unimplemented("AppClient.relaunch")
   )
   public static let mock = Self(
     colorScheme: { .light },
@@ -76,7 +80,8 @@ extension AppClient: TestDependencyKey {
     isLaunchAtLoginEnabled: { true },
     installLocation: { URL(fileURLWithPath: "/Applications/Gertrude.app") },
     installedVersion: { "1.0.0" },
-    quit: {}
+    quit: {},
+    relaunch: {}
   )
 }
 

--- a/macapp/App/Sources/LiveAppClient/LiveAppClient.swift
+++ b/macapp/App/Sources/LiveAppClient/LiveAppClient.swift
@@ -37,7 +37,8 @@ extension AppClient: DependencyKey {
       },
       quit: {
         exit(0)
-      }
+      },
+      relaunch: relaunchApp
     )
   }
 }

--- a/macapp/App/Sources/LiveAppClient/Relaunch.swift
+++ b/macapp/App/Sources/LiveAppClient/Relaunch.swift
@@ -1,0 +1,65 @@
+import Darwin
+import Foundation
+
+@Sendable func relaunchApp() async throws {
+  guard let relauncher = Bundle.main.sharedSupportURL?.appendingPathComponent("relauncher") else {
+    throw RelaunchError.nilHelperUrl
+  }
+
+  guard FileManager.default.fileExists(atPath: relauncher.path) else {
+    throw RelaunchError.helperNotFound
+  }
+
+  try await precheck(relauncher)
+
+  let proc = Process()
+  proc.executableURL = relauncher
+  proc.arguments = [Bundle.main.bundleURL.absoluteString, "--relaunch"]
+  do {
+    try proc.run()
+  } catch {
+    throw RelaunchError.relaunchProcessError(error)
+  }
+
+  try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+  exit(0)
+}
+
+// safeguards before we terminate the app, verifies:
+// 1) we can spawn and communicate w/ the relauncher
+// 2) that the relauncher can find our app url bundle
+@Sendable private func precheck(_ relauncher: URL) async throws {
+  let proc = Process()
+  let pipe = Pipe()
+  proc.executableURL = relauncher
+  proc.arguments = [Bundle.main.bundleURL.absoluteString, "--test"]
+  proc.standardOutput = pipe
+
+  do {
+    try proc.run()
+  } catch {
+    throw RelaunchError.testProcessError(error)
+  }
+
+  proc.waitUntilExit()
+
+  if proc.terminationStatus != 0 {
+    throw RelaunchError.testFailedInvalidExit(proc.terminationStatus)
+  }
+
+  let data = pipe.fileHandleForReading.readDataToEndOfFile()
+  if let output = String(data: data, encoding: .utf8) {
+    if output.trimmingCharacters(in: .whitespacesAndNewlines) != "OK" {
+      throw RelaunchError.testFailedUnexpectedOutput(output)
+    }
+  }
+}
+
+private enum RelaunchError: Error {
+  case nilHelperUrl
+  case helperNotFound
+  case testFailedInvalidExit(Int32)
+  case testFailedUnexpectedOutput(String)
+  case testProcessError(Error)
+  case relaunchProcessError(Error)
+}

--- a/macapp/Xcode/Gertrude.xcodeproj/project.pbxproj
+++ b/macapp/Xcode/Gertrude.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		7F53C599299FF6CA0097285A /* WebViews in Resources */ = {isa = PBXBuildFile; fileRef = 7F53C598299FF6CA0097285A /* WebViews */; };
 		7F8121052A1D3B7100A3E4E5 /* LiveAppClient in Frameworks */ = {isa = PBXBuildFile; productRef = 7F8121042A1D3B7100A3E4E5 /* LiveAppClient */; };
 		7F94DC8C261CF092002D4534 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F94DC8B261CF092002D4534 /* main.swift */; };
+		7FA3E6A22B851F0E00A4CE5C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA3E6A12B851F0E00A4CE5C /* main.swift */; };
+		7FA3E6A72B851FDA00A4CE5C /* relauncher in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7FA3E69F2B851F0E00A4CE5C /* relauncher */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7FD8DCA629C221E0003D135A /* LiveApiClient in Frameworks */ = {isa = PBXBuildFile; productRef = 7FD8DCA529C221E0003D135A /* LiveApiClient */; };
 		7FD8DCAD29CF1CCC003D135A /* Filter in Frameworks */ = {isa = PBXBuildFile; productRef = 7FD8DCAC29CF1CCC003D135A /* Filter */; };
 		7FD8DCAF29CF6C8D003D135A /* LiveFilterExtensionClient in Frameworks */ = {isa = PBXBuildFile; productRef = 7FD8DCAE29CF6C8D003D135A /* LiveFilterExtensionClient */; };
@@ -38,6 +40,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		7FA3E69D2B851F0E00A4CE5C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		7FA3E6A62B851FC100A4CE5C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 12;
+			files = (
+				7FA3E6A72B851FDA00A4CE5C /* relauncher in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C40A5C51229DD6A500627D50 /* Embed System Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -60,6 +81,9 @@
 		7F94DC6D261CEA75002D4534 /* Gertrude.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gertrude.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F94DC6E261CEA75002D4534 /* com.netrivet.gertrude.filter-extension.systemextension */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = "com.netrivet.gertrude.filter-extension.systemextension"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F94DC8B261CF092002D4534 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		7FA3E69F2B851F0E00A4CE5C /* relauncher */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = relauncher; sourceTree = BUILT_PRODUCTS_DIR; };
+		7FA3E6A12B851F0E00A4CE5C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		7FA3E6A82B8659C500A4CE5C /* GertrudeRelauncher.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = GertrudeRelauncher.entitlements; sourceTree = "<group>"; };
 		7FF3CD4B2992C99000387D3C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C40A5C4A229DD6A500627D50 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C40A5C4C229DD6A500627D50 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -71,6 +95,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		7FA3E69C2B851F0E00A4CE5C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C40A5C42229DD6A500627D50 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -107,6 +138,15 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		7FA3E6A02B851F0E00A4CE5C /* GertrudeRelauncher */ = {
+			isa = PBXGroup;
+			children = (
+				7FA3E6A82B8659C500A4CE5C /* GertrudeRelauncher.entitlements */,
+				7FA3E6A12B851F0E00A4CE5C /* main.swift */,
+			);
+			path = GertrudeRelauncher;
+			sourceTree = "<group>";
+		};
 		C40A5C47229DD6A500627D50 /* GertrudeFilterExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -125,9 +165,11 @@
 				7F5476DD299BCFF30084F682 /* Filter */,
 				C4B45DB722739FFF0050C59B /* Gertrude */,
 				C40A5C47229DD6A500627D50 /* GertrudeFilterExtension */,
+				7FA3E6A02B851F0E00A4CE5C /* GertrudeRelauncher */,
 				C4B45DDC2273A3450050C59B /* Frameworks */,
 				7F94DC6D261CEA75002D4534 /* Gertrude.app */,
 				7F94DC6E261CEA75002D4534 /* com.netrivet.gertrude.filter-extension.systemextension */,
+				7FA3E69F2B851F0E00A4CE5C /* relauncher */,
 			);
 			sourceTree = "<group>";
 		};
@@ -156,6 +198,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		7FA3E69E2B851F0E00A4CE5C /* relauncher */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7FA3E6A52B851F0E00A4CE5C /* Build configuration list for PBXNativeTarget "relauncher" */;
+			buildPhases = (
+				7FA3E69B2B851F0E00A4CE5C /* Sources */,
+				7FA3E69C2B851F0E00A4CE5C /* Frameworks */,
+				7FA3E69D2B851F0E00A4CE5C /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = relauncher;
+			productName = GertudeRelauncher;
+			productReference = 7FA3E69F2B851F0E00A4CE5C /* relauncher */;
+			productType = "com.apple.product-type.tool";
+		};
 		C40A5C44229DD6A500627D50 /* GertrudeFilterExtension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C40A5C54229DD6A500627D50 /* Build configuration list for PBXNativeTarget "GertrudeFilterExtension" */;
@@ -186,6 +245,7 @@
 				C4B45DB322739FFF0050C59B /* Resources */,
 				7F8121062A1D3D0A00A3E4E5 /* Copy “Launch at Login Helper” */,
 				C40A5C51229DD6A500627D50 /* Embed System Extensions */,
+				7FA3E6A62B851FC100A4CE5C /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -213,10 +273,13 @@
 			isa = PBXProject;
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Latest;
-				LastSwiftUpdateCheck = 1230;
+				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = Apple;
 				TargetAttributes = {
+					7FA3E69E2B851F0E00A4CE5C = {
+						CreatedOnToolsVersion = 14.3.1;
+					};
 					C40A5C44229DD6A500627D50 = {
 						CreatedOnToolsVersion = 11.0;
 					};
@@ -235,8 +298,6 @@
 			);
 			mainGroup = C4B45DAC22739FFF0050C59B;
 			packageReferences = (
-				7FC14B08299BF9E600FC3B13 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
-				7FD8DCA729C22286003D135A /* XCRemoteSwiftPackageReference "swift-dependencies" */,
 			);
 			productRefGroup = C4B45DAC22739FFF0050C59B;
 			projectDirPath = "";
@@ -244,6 +305,7 @@
 			targets = (
 				C4B45DB422739FFF0050C59B /* Gertrude */,
 				C40A5C44229DD6A500627D50 /* GertrudeFilterExtension */,
+				7FA3E69E2B851F0E00A4CE5C /* relauncher */,
 			);
 		};
 /* End PBXProject section */
@@ -290,6 +352,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		7FA3E69B2B851F0E00A4CE5C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7FA3E6A22B851F0E00A4CE5C /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C40A5C41229DD6A500627D50 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -319,6 +389,40 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		7FA3E6A32B851F0E00A4CE5C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WFN83LM943;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "$(inherited) -i $(PRODUCT_BUNDLE_IDENTIFIER)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.netrivet.gertrude.relauncher;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		7FA3E6A42B851F0E00A4CE5C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WFN83LM943;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "$(inherited) -i $(PRODUCT_BUNDLE_IDENTIFIER)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.netrivet.gertrude.relauncher;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C40A5C52229DD6A500627D50 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -543,6 +647,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		7FA3E6A52B851F0E00A4CE5C /* Build configuration list for PBXNativeTarget "relauncher" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7FA3E6A32B851F0E00A4CE5C /* Debug */,
+				7FA3E6A42B851F0E00A4CE5C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C40A5C54229DD6A500627D50 /* Build configuration list for PBXNativeTarget "GertrudeFilterExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/macapp/Xcode/Gertrude/Info.plist
+++ b/macapp/Xcode/Gertrude/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.1.3</string>
+    <string>2.2.0</string>
     <key>CFBundleVersion</key>
-    <string>2.1.3</string>
+    <string>2.2.0</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>

--- a/macapp/Xcode/GertrudeFilterExtension/Info.plist
+++ b/macapp/Xcode/GertrudeFilterExtension/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.1.3</string>
+    <string>2.2.0</string>
     <key>CFBundleVersion</key>
-    <string>2.1.3</string>
+    <string>2.2.0</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>NSHumanReadableCopyright</key>

--- a/macapp/Xcode/GertrudeRelauncher/GertrudeRelauncher.entitlements
+++ b/macapp/Xcode/GertrudeRelauncher/GertrudeRelauncher.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/macapp/Xcode/GertrudeRelauncher/main.swift
+++ b/macapp/Xcode/GertrudeRelauncher/main.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Darwin
+import Foundation
+import os.log
+
+let ppid = getppid()
+os_log("[G• relaunch] invoked pid/ppid: %{public}d / %{public}d", getpid(), ppid)
+
+if CommandLine.arguments.count != 3 {
+  os_log("[G• relaunch] ERR unexepected incorrect usage")
+  fputs("FAIL", stdout)
+  exit(1)
+}
+
+let appUrlString = CommandLine.arguments[1]
+guard let appUrl = URL(string: appUrlString) else {
+  os_log("[G• relaunch] ERR invalid URL string: %{public}s", appUrlString)
+  fputs("FAIL", stdout)
+  exit(1)
+}
+
+guard FileManager.default.fileExists(atPath: appUrl.path) else {
+  os_log("[G• relaunch] ERR app url 404: %{public}s", appUrl.absoluteString)
+  fputs("FAIL", stdout)
+  exit(1)
+}
+
+if CommandLine.arguments[2] == "--test" {
+  os_log("[G• relaunch] test success")
+  fputs("OK", stdout)
+  exit(0)
+}
+
+var iterations = 0
+os_log("[G• relaunch] start watching for program termination...")
+
+while true {
+  iterations += 1
+  Thread.sleep(forTimeInterval: 0.2)
+  os_log("[G• relaunch] continue watching for program termination...")
+
+  // new ppid means process was orphaned because app terminated
+  if getppid() != ppid {
+    os_log("[G• relaunch] termination detected, relaunching, new ppid: %{public}d", getppid())
+    NSWorkspace.shared.openApplication(
+      at: appUrl,
+      configuration: NSWorkspace.OpenConfiguration()
+    )
+    Thread.sleep(forTimeInterval: 0.2)
+    os_log("[G• relaunch] relaunch complete, terminating helper process")
+    exit(0)
+  }
+
+  if iterations > 100 {
+    os_log("[G• relaunch] ERR program never terminated")
+    fputs("FAIL", stdout)
+    exit(1)
+  }
+}


### PR DESCRIPTION
closes https://github.com/gertrude-app/project/issues/159

for now, this just adds a `.relaunch() async throws` function to the `AppClient` without leveraging it anywhere. later work having to do with https://github.com/gertrude-app/project/issues/163 will use this to relaunch the app if the filter gets ahead of the app version (which can happen when one macos user updates gertrude while another macos user is logged in with gertrude running).

I tested relaunching successfully on Ventura, Big Sur, and Catalina.

related issues:
* https://github.com/gertrude-app/project/issues/221
* https://github.com/gertrude-app/project/issues/222

