### PR TITLE
api: switch to keeping full E164 phone numbers in db

### DIFF
--- a/api/Sources/Api/Environment/Twilio.swift
+++ b/api/Sources/Api/Environment/Twilio.swift
@@ -12,11 +12,10 @@ struct TwilioSmsClient {
 private func send(_ text: Text) {
   let (sid, auth, from) = (Env.TWILIO_ACCOUNT_SID, Env.TWILIO_AUTH_TOKEN, Env.TWILIO_FROM_PHONE)
   let url = "https://\(sid):\(auth)@api.twilio.com/2010-04-01/Accounts/\(sid)/Messages.json"
-  let to = text.recipientI164
 
   var request = URLRequest(url: URL(string: url)!)
   request.httpMethod = "POST"
-  request.httpBody = "From=\(from)&To=\(to)&Body=\(text.message)".data(using: .utf8)
+  request.httpBody = "From=\(from)&To=\(text.to)&Body=\(text.message)".data(using: .utf8)
 
   URLSession.shared.dataTask(with: request) { data, response, error in
     if let error = error {

--- a/api/Sources/Api/Services/AdminNotifications/AdminNotifying.swift
+++ b/api/Sources/Api/Services/AdminNotifications/AdminNotifying.swift
@@ -70,10 +70,6 @@ struct Text: Equatable {
   let to: PhoneNumber
   let message: String
   typealias PhoneNumber = Tagged<Text, String>
-
-  var recipientI164: String {
-    "+1\(to.rawValue.filter(\.isNumber).drop(while: { $0 == "1" }))"
-  }
 }
 
 extension Slack {

--- a/api/Tests/ApiTests/DashboardPairResolvers/AuthedAdminResolverTests.swift
+++ b/api/Tests/ApiTests/DashboardPairResolvers/AuthedAdminResolverTests.swift
@@ -128,7 +128,7 @@ final class AuthedAdminResolverTests: ApiTestCase {
     let (id, _) = mockUUIDs()
 
     let output = try await CreatePendingNotificationMethod.resolve(
-      with: .text(phoneNumber: "1234567890"),
+      with: .text(phoneNumber: "+12345678901"),
       in: context(admin)
     )
 
@@ -140,10 +140,9 @@ final class AuthedAdminResolverTests: ApiTestCase {
 
     // check that text was sent
     expect(sent.texts).toEqual([.init(
-      to: "1234567890",
+      to: "+12345678901",
       message: "Your verification code is 987654"
     )])
-    expect(sent.texts.first?.recipientI164).toEqual("+1234567890")
 
     // submit the "confirm pending" mutation
     let confirmOuput = try await ConfirmPendingNotificationMethod.resolve(
@@ -157,7 +156,7 @@ final class AuthedAdminResolverTests: ApiTestCase {
     let retrieved = try? await Current.db.find(AdminVerifiedNotificationMethod.self, byId: id)
     expect(retrieved?.id.rawValue).toEqual(id)
     expect(retrieved?.adminId).toEqual(admin.id)
-    expect(retrieved?.config).toEqual(.text(phoneNumber: "1234567890"))
+    expect(retrieved?.config).toEqual(.text(phoneNumber: "+12345678901"))
   }
 
   func testCreatePendingMethod_Slack() async throws {


### PR DESCRIPTION
support non-US phone numbers.

we only have a dozen or so phone numbers in the db right now, so rather than write a full migration, i'm going to update the values in place at the time this goes live, prepending `+1` to all stored phone numbers (they are all US until this deploys)