### PR TITLE
macapp: prevent caching of pairql request

### DIFF
--- a/macapp/App/Sources/LiveApiClient/ApiRequest.swift
+++ b/macapp/App/Sources/LiveApiClient/ApiRequest.swift
@@ -30,7 +30,8 @@ private func request<T: Pair>(
   pair: T.Type
 ) async throws -> T.Output {
   let router = App.router.baseURL(ApiClient.endpoint.absoluteString)
-  let request = try router.request(for: .wrap(route))
+  var request = try router.request(for: .wrap(route))
+  request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
   let (data, response) = try await data(for: request)
   if let httpResponse = response as? HTTPURLResponse,
      httpResponse.statusCode >= 300 {


### PR DESCRIPTION
when i changed dns during switch to cloudflare, i had things configured wrongly temporarily. some computers seemed to cache the redirect misconfiguration incredibly stubbornly, persisting across restart/shutdown. the only fix seemed to be manually blowing away cache with `rm -rf ~/Library/Caches/com.netrivet.gertrude.app/` so this change should hopefully instruct URLRequest to never use cache under any circumstances