### PR TITLE
api: push built binary to server from gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,51 @@ jobs:
           path: api/.build
           key: api-${{ hashFiles('api/Package.resolved') }}
           restore-keys: api-
+      - name: meta
+        id: meta
+        uses: friends-library/dev/actions/ts-pack/actions/meta@master
+        with:
+          github_token: ${{ github.token }}
+      - name: set-env-vars
+        run: |
+          DATESTR=$(TZ=America/New_York date +'%Y.%m.%d_%I.%M%p')
+          SHORTSHA=${{ steps.meta.outputs.latest_commit_sha_short }}
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            API_ENV=production
+            echo "SRCDIR=api/.build/release" >> $GITHUB_ENV
+            echo "DESTDIR=builds/production" >> $GITHUB_ENV
+            echo "CONFIGURATION=release"     >> $GITHUB_ENV
+          else
+            API_ENV=staging
+            echo "SRCDIR=api/.build/debug"   >> $GITHUB_ENV
+            echo "DESTDIR=builds/staging"    >> $GITHUB_ENV
+            echo "CONFIGURATION=debug"       >> $GITHUB_ENV
+          fi
+          echo "FILENAME=api_${API_ENV}_${DATESTR}_${SHORTSHA}" >> $GITHUB_ENV
       - name: build-api
-        run: cd api && swift build
+        run: |
+          cd api && swift build --static-swift-stdlib -c $CONFIGURATION
+          cd ../ && cp ${SRCDIR}/Run ${FILENAME}
+      - name: scp-bin
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: api.gertrude.app
+          username: ${{ secrets.API_SERVER_SSH_USER }}
+          key: ${{ secrets.API_SERVER_SSH_KEY }}
+          source: '${{ env.FILENAME }}'
+          target: '${{ env.DESTDIR }}'
+      - name: ssh-tasks
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: api.gertrude.app
+          username: ${{ secrets.API_SERVER_SSH_USER }}
+          key: ${{ secrets.API_SERVER_SSH_KEY }}
+          envs: DESTDIR,FILENAME
+          script: |
+            ln -sf "./${FILENAME}" "${DESTDIR}/latest"
+            chmod +x "${DESTDIR}/${FILENAME}"
+            chmod +x "${DESTDIR}/latest"
+            pm2 restart staging
 
   linux-api-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
on monday morning i brought the production API down for about 20 minutes because i was trying to build the newest version, and something in the `swift build -c release` command just hung and chewed through all the memory and basically froze the VM. i've had this happen on the friends library vm too, i can't explain why, sometimes the swift compilation just stops making progress.

i had already explored the possibility of building the api binary offsite, and never trying to do that in the production vm, and i knew it was possible, as long as we statically link the swift std lib and build in a similar linux environment. so this PR basically formalizes this, we now build on github actions, setting the correct `--configuration` based on PR vs merge to master, and we `scp` the files to the api vm. so from now on the api vm is only responsible for running the built artifacts, never for building.  

i set it up so that PR's push staging builds which get automatically used by the staging api by restarting the `pm2` job. production deploys require one more manual step, both for safety, and because we currently temporarily drop websocket connections (and lose magic links and signup tokens) when we restart the prod server, so this is best done as sparingly as possible. long-term i'd like to mitigate or fix those issues and have prod auto deploy and restart as well, but this is a good and probably overdue step regardless.