### PR TITLE
api: add optional displayId to Screenshot

### DIFF
--- a/api/Sources/Api/Configure/migrations.swift
+++ b/api/Sources/Api/Configure/migrations.swift
@@ -30,5 +30,6 @@ extension Configure {
     app.migrations.add(AddExtraMonitoring())
     app.migrations.add(RemoveSoftDeletes())
     app.migrations.add(RemoveUserTokenNullable())
+    app.migrations.add(ScreenshotDisplayId())
   }
 }

--- a/api/Sources/Api/Database/Migrations/027_ScreenshotDisplayId.swift
+++ b/api/Sources/Api/Database/Migrations/027_ScreenshotDisplayId.swift
@@ -1,0 +1,27 @@
+import FluentSQL
+import Foundation
+import Gertie
+
+struct ScreenshotDisplayId: GertieMigration {
+  func up(sql: SQLDatabase) async throws {
+    try await sql.addColumn(
+      Screenshot.M27.displayId,
+      on: Screenshot.M4.self,
+      type: .int,
+      nullable: true
+    )
+  }
+
+  func down(sql: SQLDatabase) async throws {
+    try await sql.dropColumn(
+      Screenshot.M27.displayId,
+      on: Screenshot.M4.self
+    )
+  }
+}
+
+extension Screenshot {
+  enum M27 {
+    static let displayId = FieldKey("display_id")
+  }
+}

--- a/api/Sources/Api/Models/Activity/Screenshot.swift
+++ b/api/Sources/Api/Models/Activity/Screenshot.swift
@@ -6,6 +6,7 @@ struct Screenshot: Codable, Sendable {
   var url: String
   var width: Int
   var height: Int
+  var displayId: Int?
   var filterSuspended: Bool
   var createdAt: Date
   var deletedAt: Date?
@@ -16,6 +17,7 @@ struct Screenshot: Codable, Sendable {
     url: String,
     width: Int,
     height: Int,
+    displayId: Int? = nil,
     filterSuspended: Bool = false,
     createdAt: Date = Date()
   ) {
@@ -24,6 +26,7 @@ struct Screenshot: Codable, Sendable {
     self.url = url
     self.width = width
     self.height = height
+    self.displayId = displayId
     self.filterSuspended = filterSuspended
     self.createdAt = createdAt
   }

--- a/api/Sources/Api/Models/Models+Duet.swift
+++ b/api/Sources/Api/Models/Models+Duet.swift
@@ -295,6 +295,7 @@ extension Screenshot {
     case url
     case width
     case height
+    case displayId
     case filterSuspended
     case createdAt
     case deletedAt

--- a/api/Sources/Api/Models/Models+DuetSQL.swift
+++ b/api/Sources/Api/Models/Models+DuetSQL.swift
@@ -399,6 +399,7 @@ extension Screenshot: Model {
     case .url: .string(self.url)
     case .width: .int(self.width)
     case .height: .int(self.height)
+    case .displayId: .int(self.displayId)
     case .filterSuspended: .bool(self.filterSuspended)
     case .createdAt: .date(self.createdAt)
     case .deletedAt: .date(self.deletedAt)
@@ -412,6 +413,7 @@ extension Screenshot: Model {
       .url: .string(self.url),
       .width: .int(self.width),
       .height: .int(self.height),
+      .displayId: .int(self.displayId),
       .filterSuspended: .bool(self.filterSuspended),
       .createdAt: .date(self.createdAt),
       .deletedAt: .date(self.deletedAt),

--- a/api/Sources/Api/PairQL/MacApp/Resolvers/CreateSignedScreenshotUpload.swift
+++ b/api/Sources/Api/PairQL/MacApp/Resolvers/CreateSignedScreenshotUpload.swift
@@ -33,6 +33,7 @@ extension CreateSignedScreenshotUpload: Resolver {
       url: webUrlString,
       width: input.width,
       height: input.height,
+      displayId: input.displayId,
       filterSuspended: input.filterSuspended ?? false,
       createdAt: input.createdAt ?? get(dependency: \.date.now)
     ))

--- a/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
@@ -145,7 +145,7 @@ final class MacAppResolverTests: ApiTestCase {
     expect(afterCount).toEqual(beforeCount + 1)
   }
 
-  func testCreateSignedScreenshotUploadWithDate() async throws {
+  func testCreateSignedScreenshotUploadWithAllData() async throws {
     let user = try await self.userWithDevice()
     let uuids = MockUUIDs()
 
@@ -154,12 +154,20 @@ final class MacAppResolverTests: ApiTestCase {
       $0.uuid = .mock(uuids)
     } operation: {
       _ = try await CreateSignedScreenshotUpload.resolve(
-        with: .init(width: 1116, height: 222, createdAt: .epoch),
+        with: .init(
+          width: 1116,
+          height: 222,
+          displayId: 2,
+          filterSuspended: true,
+          createdAt: .epoch
+        ),
         in: self.context(user)
       )
       let screenshot = try await self.db.find(Screenshot.Id(uuids[1]))
       expect(screenshot.width).toEqual(1116)
       expect(screenshot.createdAt).toEqual(.epoch)
+      expect(screenshot.displayId).toEqual(2)
+      expect(screenshot.filterSuspended).toEqual(true)
     }
   }
 

--- a/pairql-macapp/Sources/MacAppRoute/Pairs/CreateSignedScreenshotUpload.swift
+++ b/pairql-macapp/Sources/MacAppRoute/Pairs/CreateSignedScreenshotUpload.swift
@@ -13,18 +13,21 @@ public struct CreateSignedScreenshotUpload: Pair {
   public struct Input: PairInput {
     public let width: Int
     public let height: Int
+    public let displayId: Int? // added v2.5.0, backwards compatible
     public var filterSuspended: Bool?
     public let createdAt: Date?
 
     public init(
       width: Int,
       height: Int,
+      displayId: Int? = nil,
       filterSuspended: Bool? = false,
       createdAt: Date? = nil
     ) {
       self.width = width
       self.height = height
       self.filterSuspended = filterSuspended
+      self.displayId = displayId
       self.createdAt = createdAt
     }
   }


### PR DESCRIPTION
see https://github.com/gertrude-app/project/issues/272

adds an optional field to `Screenshot`, backwards compatible in DB and model, so wanting to deploy immediately to aid with testing canary builds of 2.5.0 on sequoia.

the change has to do with the fact that to avoid a misleading, scary warning in Sequoia that makes it seem like we're recording audio and bypassing privacy settings, we need to use an updated screenshot API. but that API doesn't make conglomerate images when there are multiple displays. so we upload the images separately in Sequoia+, and keep track of the display id in the database, so that we can sort by them, presenting the parent with consistent groupings of screenshot images (i.e.: left monitor always first, right monitor always second)