### PR TITLE
api: revert screenshot display id

### DIFF
--- a/api/Sources/Api/Configure/migrations.swift
+++ b/api/Sources/Api/Configure/migrations.swift
@@ -31,5 +31,6 @@ extension Configure {
     app.migrations.add(RemoveSoftDeletes())
     app.migrations.add(RemoveUserTokenNullable())
     app.migrations.add(ScreenshotDisplayId())
+    app.migrations.add(RevertScreenshotDisplayId())
   }
 }

--- a/api/Sources/Api/Database/Migrations/027_ScreenshotDisplayId.swift
+++ b/api/Sources/Api/Database/Migrations/027_ScreenshotDisplayId.swift
@@ -20,6 +20,16 @@ struct ScreenshotDisplayId: GertieMigration {
   }
 }
 
+struct RevertScreenshotDisplayId: GertieMigration {
+  func up(sql: SQLDatabase) async throws {
+    try await ScreenshotDisplayId().down(sql: sql)
+  }
+
+  func down(sql: SQLDatabase) async throws {
+    try await ScreenshotDisplayId().up(sql: sql)
+  }
+}
+
 extension Screenshot {
   enum M27 {
     static let displayId = FieldKey("display_id")

--- a/api/Sources/Api/Models/Activity/Screenshot.swift
+++ b/api/Sources/Api/Models/Activity/Screenshot.swift
@@ -6,7 +6,6 @@ struct Screenshot: Codable, Sendable {
   var url: String
   var width: Int
   var height: Int
-  var displayId: Int?
   var filterSuspended: Bool
   var createdAt: Date
   var deletedAt: Date?
@@ -17,7 +16,6 @@ struct Screenshot: Codable, Sendable {
     url: String,
     width: Int,
     height: Int,
-    displayId: Int? = nil,
     filterSuspended: Bool = false,
     createdAt: Date = Date()
   ) {
@@ -26,7 +24,6 @@ struct Screenshot: Codable, Sendable {
     self.url = url
     self.width = width
     self.height = height
-    self.displayId = displayId
     self.filterSuspended = filterSuspended
     self.createdAt = createdAt
   }

--- a/api/Sources/Api/Models/Models+Duet.swift
+++ b/api/Sources/Api/Models/Models+Duet.swift
@@ -295,7 +295,6 @@ extension Screenshot {
     case url
     case width
     case height
-    case displayId
     case filterSuspended
     case createdAt
     case deletedAt

--- a/api/Sources/Api/Models/Models+DuetSQL.swift
+++ b/api/Sources/Api/Models/Models+DuetSQL.swift
@@ -399,7 +399,6 @@ extension Screenshot: Model {
     case .url: .string(self.url)
     case .width: .int(self.width)
     case .height: .int(self.height)
-    case .displayId: .int(self.displayId)
     case .filterSuspended: .bool(self.filterSuspended)
     case .createdAt: .date(self.createdAt)
     case .deletedAt: .date(self.deletedAt)
@@ -413,7 +412,6 @@ extension Screenshot: Model {
       .url: .string(self.url),
       .width: .int(self.width),
       .height: .int(self.height),
-      .displayId: .int(self.displayId),
       .filterSuspended: .bool(self.filterSuspended),
       .createdAt: .date(self.createdAt),
       .deletedAt: .date(self.deletedAt),

--- a/api/Sources/Api/PairQL/MacApp/Resolvers/CreateSignedScreenshotUpload.swift
+++ b/api/Sources/Api/PairQL/MacApp/Resolvers/CreateSignedScreenshotUpload.swift
@@ -33,7 +33,6 @@ extension CreateSignedScreenshotUpload: Resolver {
       url: webUrlString,
       width: input.width,
       height: input.height,
-      displayId: input.displayId,
       filterSuspended: input.filterSuspended ?? false,
       createdAt: input.createdAt ?? get(dependency: \.date.now)
     ))

--- a/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
@@ -145,7 +145,7 @@ final class MacAppResolverTests: ApiTestCase {
     expect(afterCount).toEqual(beforeCount + 1)
   }
 
-  func testCreateSignedScreenshotUploadWithAllData() async throws {
+  func testCreateSignedScreenshotUploadWithDate() async throws {
     let user = try await self.userWithDevice()
     let uuids = MockUUIDs()
 
@@ -154,20 +154,12 @@ final class MacAppResolverTests: ApiTestCase {
       $0.uuid = .mock(uuids)
     } operation: {
       _ = try await CreateSignedScreenshotUpload.resolve(
-        with: .init(
-          width: 1116,
-          height: 222,
-          displayId: 2,
-          filterSuspended: true,
-          createdAt: .epoch
-        ),
+        with: .init(width: 1116, height: 222, createdAt: .epoch),
         in: self.context(user)
       )
       let screenshot = try await self.db.find(Screenshot.Id(uuids[1]))
       expect(screenshot.width).toEqual(1116)
       expect(screenshot.createdAt).toEqual(.epoch)
-      expect(screenshot.displayId).toEqual(2)
-      expect(screenshot.filterSuspended).toEqual(true)
     }
   }
 

--- a/pairql-macapp/Sources/MacAppRoute/Pairs/CreateSignedScreenshotUpload.swift
+++ b/pairql-macapp/Sources/MacAppRoute/Pairs/CreateSignedScreenshotUpload.swift
@@ -13,21 +13,18 @@ public struct CreateSignedScreenshotUpload: Pair {
   public struct Input: PairInput {
     public let width: Int
     public let height: Int
-    public let displayId: Int? // added v2.5.0, backwards compatible
     public var filterSuspended: Bool?
     public let createdAt: Date?
 
     public init(
       width: Int,
       height: Int,
-      displayId: Int? = nil,
       filterSuspended: Bool? = false,
       createdAt: Date? = nil
     ) {
       self.width = width
       self.height = height
       self.filterSuspended = filterSuspended
-      self.displayId = displayId
       self.createdAt = createdAt
     }
   }


### PR DESCRIPTION
basically reverts 2de0667

turns out there's no current way to avoid the scary warning, so no reason to switch to the new apis which necessitated this new field.

see https://github.com/gertrude-app/project/issues/272
see https://developer.apple.com/forums/thread/765103