### PR TITLE
gertie: introduce time span primitives

### DIFF
--- a/api/Sources/Api/PairQL/MacApp/Resolvers/LogSecurityEvent.swift
+++ b/api/Sources/Api/PairQL/MacApp/Resolvers/LogSecurityEvent.swift
@@ -19,8 +19,10 @@ extension LogSecurityEvent: Resolver {
 
     guard let event = Gertie.SecurityEvent.MacApp(rawValue: input.event) else {
       if input.event != "appUpdateInitiated" { // <-- removed for noise
-        await with(dependency: \.slack)
-          .sysLog(to: "errors", "Received unknown security event: `\(input.event)`")
+        await with(dependency: \.slack).sysLog(
+          to: "errors",
+          "Unknown security event: `\(input.event)`, detail: \(input.detail ?? "(nil)")"
+        )
       }
       return .success
     }

--- a/gertie/Sources/Gertie/Time.swift
+++ b/gertie/Sources/Gertie/Time.swift
@@ -1,0 +1,27 @@
+/// A wall-clock time not associated with a particular date or time zone
+public struct PlainTime {
+  var hour: UInt8
+  var minute: UInt8
+
+  public init(hour: UInt8, minute: UInt8) {
+    self.hour = hour
+    self.minute = minute
+  }
+}
+
+/// A time "window"  with a start and end not
+/// associated with a particular date or time zone
+public struct PlainTimeWindow {
+  var start: PlainTime
+  var end: PlainTime
+
+  public init(start: PlainTime, end: PlainTime) {
+    self.start = start
+    self.end = end
+  }
+}
+
+// extensions
+
+extension PlainTime: Sendable, Equatable, Hashable, Codable {}
+extension PlainTimeWindow: Sendable, Equatable, Hashable, Codable {}


### PR DESCRIPTION
introduces `PlainTime` and `PlainTimeWindow` time primitives.  i took the "Plain" verbage from js temporal because i was struggling with naming -- these convey the idea of time values independent of a specific absolute date time or timezone. js temporal uses "Plain" for this concept, so i went with it.

i want to start using these structs in the macapp, so i put it in `Gertie` because it will be shared eventually between the api and the mac app. `Gertie` is our shared "models" and types SPM package. stuff goes in there if the API and the macapp need it.

submitting this now as a PR because it will also unblock a task for you @kiahjh if you want it. basically, once this is merged, you could tackle adding a `.downtime` stored property on the `UserDevice` model, which would be a `PlainTimeWindow?`.  you'd need to do a migration, handle the database json stuff, and probably expose it as a new field on the `CheckIn.Output` pairql struct for the macapp to consume, w/ tests.  no worries if that doesn't seem interesting to you, i'm happy to do it, but if you want to take a whack at it, you're welcome to.