### PR TITLE
x-postmark,api: rough-in template email sending

### DIFF
--- a/api/Sources/Api/PairQL/Dashboard/Pairs/SendPasswordResetEmail.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/SendPasswordResetEmail.swift
@@ -27,10 +27,10 @@ extension SendPasswordResetEmail: Resolver {
         .createAdminIdToken(admin.id)
       dashSecurityEvent(.passwordResetRequested, admin: admin.id, in: context)
       try await with(dependency: \.postmark)
-        .send(reset(email, context.dashboardUrl, token))
+        .sendEmail(reset(email, context.dashboardUrl, token)).get()
     } else {
       try await with(dependency: \.postmark)
-        .send(notFound(email))
+        .sendEmail(notFound(email)).get()
     }
     return .success
   }
@@ -43,7 +43,7 @@ private func reset(_ email: String, _ dashboardUrl: String, _ token: UUID) -> XP
     to: email,
     from: "Gertrude App <noreply@gertrude.app>",
     subject: "Gertrude password reset".withEmailSubjectDisambiguator,
-    html: """
+    htmlBody: """
     You can reset your Gertrude account password by clicking \
     <a href="\(dashboardUrl)/reset-password/\(token.lowercased)">here</a>.
     """
@@ -55,7 +55,7 @@ private func notFound(_ email: String) -> XPostmark.Email {
     to: email,
     from: "Gertrude App <noreply@gertrude.app>",
     subject: "Gertrude app password reset".withEmailSubjectDisambiguator,
-    html: """
+    htmlBody: """
     A password reset was requested for this email address, \
     but no Gertrude account exists with this email address. \
     Perhaps you signed up with a different email address? <br /><br /> \

--- a/api/Sources/Api/Services/Jobs/SubscriptionEmails.swift
+++ b/api/Sources/Api/Services/Jobs/SubscriptionEmails.swift
@@ -24,7 +24,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "[action required] Gertrude trial ending soon".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Hi there! 👋</p>
 
       <p>
@@ -51,7 +51,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "[action required] Gertrude trial ended".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Gertrude parent account holder,</p>
 
       <p>
@@ -88,7 +88,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "[action required] Gertrude account disabled".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Gertrude parent account holder,</p>
 
       <p>
@@ -124,7 +124,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "[action required] Gertrude payment failed".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Gertrude parent account holder,</p>
 
       <p>
@@ -164,7 +164,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "[action required] Gertrude account will be deleted".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Gertrude parent account holder,</p>
 
       <p>
@@ -192,7 +192,7 @@ enum SubscriptionEmails {
       from: "Gertrude App <noreply@gertrude.app>",
       replyTo: get(dependency: \.env).primarySupportEmail,
       subject: "Gertrude unverified account deleted".withEmailSubjectDisambiguator,
-      html: """
+      htmlBody: """
       <p>Hi there! 👋</p>
 
       <p>

--- a/api/Sources/Api/Services/Jobs/SubscriptionManager.swift
+++ b/api/Sources/Api/Services/Jobs/SubscriptionManager.swift
@@ -65,8 +65,12 @@ struct SubscriptionManager: AsyncScheduledJob {
       }
 
       if let event = update.email {
-        try await self.postmark.send(SubscriptionEmails.email(event, to: admin.email))
-        logs.append("Sent `.\(event)` email to admin \(admin.email)")
+        switch await self.postmark.sendEmail(SubscriptionEmails.email(event, to: admin.email)) {
+        case .success:
+          logs.append("Sent `.\(event)` email to admin \(admin.email)")
+        case .failure(let error):
+          logs.append("Failed to send `.\(event)` email to admin \(admin.email): \(error)")
+        }
       }
     }
 

--- a/api/Tests/ApiTests/ApiTestCase.swift
+++ b/api/Tests/ApiTests/ApiTestCase.swift
@@ -34,8 +34,9 @@ class ApiTestCase: XCTestCase {
         self.sent.slacks.append(.init(message: msg, token: tok))
         return nil
       }
-      $0.postmark.send = {
+      $0.postmark.sendEmail = {
         self.sent.postmarkEmails.append($0)
+        return .success(())
       }
       $0.sendgrid.send = {
         self.sent.sendgridEmails.append($0)

--- a/api/Tests/ApiTests/DashboardPairResolvers/UnauthedResolverTests.swift
+++ b/api/Tests/ApiTests/DashboardPairResolvers/UnauthedResolverTests.swift
@@ -22,7 +22,7 @@ final class DasboardUnauthedResolverTests: ApiTestCase {
 
     expect(output).toEqual(.success)
     expect(sent.postmarkEmails.count).toEqual(1)
-    expect(sent.postmarkEmails[0].html).toContain("already has an account")
+    expect(sent.postmarkEmails[0].body).toContain("already has an account")
   }
 
   func testInitiateSignupHappyPath() async throws {
@@ -39,7 +39,7 @@ final class DasboardUnauthedResolverTests: ApiTestCase {
     expect(admin.subscriptionStatusExpiration).toEqual(.reference.advanced(by: .days(7)))
     expect(sent.postmarkEmails.count).toEqual(1)
     expect(sent.postmarkEmails[0].to).toEqual(email)
-    expect(sent.postmarkEmails[0].html).toContain("verify your email address")
+    expect(sent.postmarkEmails[0].body).toContain("verify your email address")
   }
 
   func testInitiateSignupWithGclidAndABVariant() async throws {

--- a/api/Tests/ApiTests/DashboardPairResolvers/VerifySignupEmailResolverTests.swift
+++ b/api/Tests/ApiTests/DashboardPairResolvers/VerifySignupEmailResolverTests.swift
@@ -38,7 +38,7 @@ final class VerifySignupEmailResolverTests: ApiTestCase {
     expect(result).toBeError(containing: "expired, but we sent a new verification email")
     expect(sent.postmarkEmails).toHaveCount(1)
     expect(sent.postmarkEmails[0].to).toEqual(admin.email.rawValue)
-    expect(sent.postmarkEmails[0].html).toContain("verify your email address")
+    expect(sent.postmarkEmails[0].body).toContain("verify your email address")
   }
 
   func testReVerifyingExpiredTokenErrorsWithHelpfulMessage() async throws {
@@ -85,6 +85,6 @@ final class VerifySignupEmailResolverTests: ApiTestCase {
     expect(result).toBeError(containing: "until your email is verified")
     expect(sent.postmarkEmails).toHaveCount(1)
     expect(sent.postmarkEmails[0].to).toEqual(admin.email.rawValue)
-    expect(sent.postmarkEmails[0].html).toContain("verify your email address")
+    expect(sent.postmarkEmails[0].body).toContain("verify your email address")
   }
 }

--- a/x-postmark/Sources/XPostmark/Client.swift
+++ b/x-postmark/Sources/XPostmark/Client.swift
@@ -1,100 +1,70 @@
 import Foundation
 import XHttp
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
-
 public struct Client: Sendable {
-  public var send: @Sendable (Email) async throws -> Void
+  public var sendEmail: @Sendable (Email) async -> Result<Void, Client.Error>
+  public var sendTemplateEmail: @Sendable (TemplateEmail) async -> Result<Void, Client.Error>
+  public var sendTemplateEmailBatch: @Sendable ([TemplateEmail]) async
+    -> Result<[Result<Void, Client.BatchEmail.Error>], Client.Error>
 
-  public init(send: @Sendable @escaping (Email) async throws -> Void) {
-    self.send = send
-  }
-}
-
-public struct Email: Sendable {
-  public var to: String
-  public var from: String
-  public var replyTo: String?
-  public var subject: String
-  public var html: String
-
-  public init(to: String, from: String, replyTo: String? = nil, subject: String, html: String) {
-    self.to = to
-    self.from = from
-    self.replyTo = replyTo
-    self.subject = subject
-    self.html = html
+  public init(
+    sendEmail: @escaping @Sendable (Email) async -> Result<Void, Client.Error>,
+    sendTemplateEmail: @escaping @Sendable (TemplateEmail) async -> Result<Void, Client.Error>,
+    sendTemplateEmailBatch: @escaping @Sendable ([TemplateEmail]) async
+      -> Result<[Result<Void, Client.BatchEmail.Error>], Client.Error>
+  ) {
+    self.sendEmail = sendEmail
+    self.sendTemplateEmail = sendTemplateEmail
+    self.sendTemplateEmailBatch = sendTemplateEmailBatch
   }
 }
 
 // extensions
 
 public extension Client {
-  struct Error: Swift.Error, Sendable {
-    public let statusCode: Int
-    public let errorCode: Int
-    public let message: String
+  enum BatchEmail {
+    public struct Error: Swift.Error, Encodable {
+      public var errorCode: Int
+      public var message: String
+    }
+  }
+
+  struct Error: Swift.Error, Encodable {
+    public var statusCode: Int
+    public var errorCode: Int
+    public var message: String
+
+    public init(statusCode: Int, errorCode: Int, message: String) {
+      self.statusCode = statusCode
+      self.errorCode = errorCode
+      self.message = message
+    }
   }
 
   static func live(apiKey: String) -> Self {
-    Client(send: { email in
-      let (data, urlResponse) = try await HTTP.postJson(
-        ApiEmail(email: email),
-        to: "https://api.postmarkapp.com/email",
-        headers: [
-          "Accept": "application/json",
-          "X-Postmark-Server-Token": apiKey,
-        ]
-      )
-
-      if urlResponse.statusCode == 200 {
-        return
+    Client(
+      sendEmail: { email in
+        await sendSingle(.email(email), apiKey)
+      },
+      sendTemplateEmail: { email in
+        await sendSingle(.template(email), apiKey)
+      },
+      sendTemplateEmailBatch: { email in
+        await _sendTemplateEmailBatch(email, apiKey)
       }
-
-      let response: ApiResponse
-      do {
-        response = try JSONDecoder().decode(ApiResponse.self, from: data)
-      } catch {
-        throw Error(
-          statusCode: urlResponse.statusCode,
-          errorCode: -1,
-          message: "Error decoding Postmark response: \(error)"
-        )
-      }
-      throw Error(
-        statusCode: urlResponse.statusCode,
-        errorCode: response.ErrorCode,
-        message: response.Message
-      )
-    })
+    )
   }
 }
 
 public extension Client {
-  static let mock: Self = .init(send: { _ in })
+  static let mock = Client(
+    sendEmail: { _ in .success(()) },
+    sendTemplateEmail: { _ in .success(()) },
+    sendTemplateEmailBatch: { _ in .success([]) }
+  )
 }
 
 // api types
-
-struct ApiEmail: Encodable {
-  let From: String
-  let To: String
-  let Subject: String
-  let HtmlBody: String
-  let ReplyTo: String?
-  let TrackOpens: Bool
-
-  init(email: Email) {
-    self.From = email.from
-    self.To = email.to
-    self.Subject = email.subject
-    self.HtmlBody = email.html
-    self.ReplyTo = email.replyTo
-    self.TrackOpens = true
-  }
-}
 
 struct ApiResponse: Decodable {
   let ErrorCode: Int

--- a/x-postmark/Sources/XPostmark/Email.swift
+++ b/x-postmark/Sources/XPostmark/Email.swift
@@ -1,0 +1,135 @@
+import Foundation
+import XHttp
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+public struct Email {
+  public var to: String
+  public var from: String
+  public var replyTo: String?
+  public var subject: String
+
+  /// invariant: one of these is always set
+  public private(set) var htmlBody: String?
+  public private(set) var textBody: String?
+
+  public var body: String {
+    self.htmlBody ?? self.textBody ?? ""
+  }
+
+  public init(
+    to: String,
+    from: String,
+    replyTo: String? = nil,
+    subject: String,
+    textBody: String,
+    htmlBody: String? = nil
+  ) {
+    self.to = to
+    self.from = from
+    self.replyTo = replyTo
+    self.subject = subject
+    self.textBody = textBody
+    self.htmlBody = htmlBody
+  }
+
+  public init(
+    to: String,
+    from: String,
+    replyTo: String? = nil,
+    subject: String,
+    htmlBody: String,
+    textBody: String? = nil
+  ) {
+    self.to = to
+    self.from = from
+    self.replyTo = replyTo
+    self.subject = subject
+    self.htmlBody = htmlBody
+    self.textBody = textBody
+  }
+}
+
+enum SingleEmail {
+  case email(Email)
+  case template(TemplateEmail)
+}
+
+@Sendable func sendSingle(
+  _ email: SingleEmail,
+  _ apiKey: String
+) async -> Result<Void, Client.Error> {
+  do {
+    let headers = [
+      "Accept": "application/json",
+      "X-Postmark-Server-Token": apiKey,
+    ]
+    let data: Data
+    let urlResponse: HTTPURLResponse
+    switch email {
+    case .email(let email):
+      (data, urlResponse) = try await HTTP.postJson(
+        ApiEmail(email: email),
+        to: "https://api.postmarkapp.com/email",
+        headers: headers
+      )
+    case .template(let email):
+      (data, urlResponse) = try await HTTP.postJson(
+        ApiTemplateEmail(email: email),
+        to: "https://api.postmarkapp.com/email/withTemplate",
+        headers: headers
+      )
+    }
+    if urlResponse.statusCode == 200 {
+      return .success(())
+    }
+
+    do {
+      let decoded = try JSONDecoder().decode(ApiResponse.self, from: data)
+      return .failure(Client.Error(
+        statusCode: urlResponse.statusCode,
+        errorCode: decoded.ErrorCode,
+        message: decoded.Message
+      ))
+    } catch {
+      let body = String(decoding: data, as: UTF8.self)
+      return .failure(Client.Error(
+        statusCode: urlResponse.statusCode,
+        errorCode: -1,
+        message: "Error decoding Postmark response: \(error), body: \(body)"
+      ))
+    }
+  } catch {
+    return .failure(Client.Error(
+      statusCode: -2,
+      errorCode: -2,
+      message: "Error sending Postmark email: \(error)"
+    ))
+  }
+}
+
+struct ApiEmail: Encodable {
+  let From: String
+  let To: String
+  let Subject: String
+  let HtmlBody: String?
+  let TextBody: String?
+  let ReplyTo: String?
+  let TrackOpens: Bool
+
+  init(email: Email) {
+    self.From = email.from
+    self.To = email.to
+    self.Subject = email.subject
+    self.HtmlBody = email.htmlBody
+    self.TextBody = email.textBody
+    self.ReplyTo = email.replyTo
+    self.TrackOpens = true
+  }
+}
+
+// conformances
+
+extension Email: Sendable, Equatable, Hashable {}

--- a/x-postmark/Sources/XPostmark/Template.swift
+++ b/x-postmark/Sources/XPostmark/Template.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XHttp
+
+public struct TemplateEmail: Equatable {
+  public var to: String
+  public var from: String
+  public var templateAlias: String
+  public var templateModel: [String: String] = [:]
+  public var messageStream: String?
+
+  public init(
+    to: String,
+    from: String,
+    templateAlias: String,
+    templateModel: [String: String] = [:],
+    messageStream: String? = nil
+  ) {
+    self.to = to
+    self.from = from
+    self.templateAlias = templateAlias
+    self.templateModel = templateModel
+    self.messageStream = messageStream
+  }
+}
+
+@Sendable func _sendTemplateEmailBatch(
+  _ emails: [TemplateEmail],
+  _ apiKey: String
+) async -> Result<[Result<Void, Client.BatchEmail.Error>], Client.Error> {
+  if emails.count >= 500 {
+    return .failure(.init(
+      statusCode: -3,
+      errorCode: -3,
+      message: "Batched chunking not implemented, size must be less than 500"
+    ))
+  }
+  do {
+    let (data, urlResponse) = try await HTTP.postJson(
+      Batch(Messages: emails.map(ApiTemplateEmail.init)),
+      to: "https://api.postmarkapp.com/email/batchWithTemplates",
+      headers: [
+        "Accept": "application/json",
+        "X-Postmark-Server-Token": apiKey,
+      ]
+    )
+    do {
+      if urlResponse.statusCode != 200 {
+        let decoded = try JSONDecoder().decode(ApiResponse.self, from: data)
+        return .failure(Client.Error(
+          statusCode: urlResponse.statusCode,
+          errorCode: decoded.ErrorCode,
+          message: decoded.Message
+        ))
+      } else {
+        let responses = try JSONDecoder().decode([BatchEmailResponse].self, from: data)
+        return .success(responses.map { response in
+          if response.ErrorCode == 0 {
+            return .success(())
+          } else {
+            return .failure(.init(
+              errorCode: response.ErrorCode,
+              message: response.Message
+            ))
+          }
+        })
+      }
+    } catch {
+      let body = String(decoding: data, as: UTF8.self)
+      return .failure(Client.Error(
+        statusCode: urlResponse.statusCode,
+        errorCode: -4,
+        message: "Error decoding Postmark batch response: \(error), body: \(body)"
+      ))
+    }
+  } catch {
+    return .failure(Client.Error(
+      statusCode: -5,
+      errorCode: -5,
+      message: "Error sending Postmark batch emails: \(error)"
+    ))
+  }
+}
+
+struct Batch: Encodable {
+  let Messages: [ApiTemplateEmail]
+}
+
+struct BatchEmailResponse: Decodable {
+  let ErrorCode: Int
+  let Message: String
+}
+
+struct ApiTemplateEmail: Encodable {
+  let To: String
+  let From: String
+  let TemplateAlias: String
+  let TemplateModel: [String: String]
+  let MessageStream: String?
+}
+
+extension ApiTemplateEmail {
+  init(email: TemplateEmail) {
+    self.To = email.to
+    self.From = email.from
+    self.TemplateAlias = email.templateAlias
+    self.TemplateModel = email.templateModel
+    self.MessageStream = email.messageStream
+  }
+}


### PR DESCRIPTION
this is a bit rough, the forking of logic i do to send via Postmark and Sendgrid makes this awkward. it's likely that we'll soon cross into needing to pay for postmark because of this feature anyway, so i think the proper cleanup is just to delete the sendgrid integration. but this at least will give you something to test with by pulling this branch down locally, and i'll decide if i want to merge as is or do the proper cleanup first then merge.

once you have this running locally, you can add some code like this in `configure/app.swift`:

```swift
    Task {
      switch await with(dependency: \.postmark).sendTemplateEmail(.init(
        to: "jared@netrivet.com",
        from: "noreply@gertrude.app",
        templateAlias: "welcome",
        templateModel: [
          "product_url": "https://gertrude.app",
          "product_name": "Gertrude",
          "name": "Bob Smith",
          "action_url": "/",
          "login_url": "/",
          "username": "bobsmith123",
          "trial_length": "17 years",
          "trial_start_date": "just now",
          "trial_end_date": "2048",
          "support_email": "noreply@gertrude.app",
          "live_chat_url": "/",
          "sender_name": "Jared",
          "help_url": "/",
          "company_name": "Gertrude Labs",
          "company_address": "123 Main St",
        ],
        messageStream: "broadcast"
      )) {
      case .success:
        print("Email sent")
      case .failure(let error):
        print("Email failed: \(error)")
      }
    }
```

i'll send you a postmark api key and some login credentials too