### PR TITLE
api: try to prevent/improve expired/404 app connect errors

### DIFF
--- a/api/Sources/Api/Environment/Ephemeral.swift
+++ b/api/Sources/Api/Environment/Ephemeral.swift
@@ -30,7 +30,7 @@ actor Ephemeral {
     let token = self.uuid()
     self.adminIds[token] = (
       adminId: adminId,
-      expiration: expiration ?? self.now + ONE_HOUR
+      expiration: expiration ?? self.now + .minutes(60)
     )
     return token
   }
@@ -75,7 +75,7 @@ actor Ephemeral {
     self.pendingMethods[model.id] = (
       model: model,
       code: code,
-      expiration: expiration ?? self.now + ONE_HOUR
+      expiration: expiration ?? self.now + .minutes(60)
     )
     return code
   }
@@ -104,7 +104,7 @@ actor Ephemeral {
     }
     self.pendingAppConnections[code] = (
       userId: userId,
-      expiration: expiration ?? self.now + ONE_HOUR
+      expiration: expiration ?? self.now + .days(2)
     )
     return code
   }
@@ -120,8 +120,6 @@ actor Ephemeral {
     return userId
   }
 }
-
-private let ONE_HOUR: TimeInterval = 60 * 60
 
 // dependency
 

--- a/api/Sources/Api/PairQL/MacApp/Resolvers/ConnectUser.swift
+++ b/api/Sources/Api/PairQL/MacApp/Resolvers/ConnectUser.swift
@@ -12,7 +12,7 @@ extension ConnectUser: Resolver {
         id: "6e7fc234",
         type: .unauthorized,
         debugMessage: "verification code not found",
-        userMessage: "Connection code not found, or expired. Please try again.",
+        userMessage: "Connection code expired, or not found. Plese create a new code and try again.",
         appTag: .connectionCodeNotFound
       )
     }


### PR DESCRIPTION
in a weird stretch where almost nobody is successfully onboarding, can't figure out why. have seen at least 2 "expired/not found" connection code errors, so bumping the alive time to 2 days, and tweaking the error message to make it more explicit that they can click to create a new code when this happens.