### PR TITLE
iosapp: final ui tweaks for 1.3.0

### DIFF
--- a/iosapp/app/App.swift
+++ b/iosapp/app/App.swift
@@ -10,8 +10,7 @@ struct AppView: View {
 
   var body: some View {
     switch self.store.screen {
-    case .launching:
-      EmptyView()
+    case .launching: EmptyView()
 
     case .onboarding(.happyPath(.hiThere)):
       WelcomeView {
@@ -25,7 +24,8 @@ struct AppView: View {
 
     case .onboarding(.happyPath(.timeExpectation)):
       ButtonScreenView(
-        text: "The setup usually takes about 5-7 minutes, but in some cases extra steps are required.",
+        text:
+          "The setup usually takes about 5-7 minutes, but in some cases extra steps are required.",
         primary: self.btn(text: "Next", .primary)
       )
 
@@ -59,7 +59,8 @@ struct AppView: View {
 
     case .onboarding(.happyPath(.confirmInAppleFamily)):
       ButtonScreenView(
-        text: "Apple also requires that the child’s device be part of an Apple Family. Is the Apple Account for this device already in an Apple Family?",
+        text:
+          "Apple also requires that the child’s device be part of an Apple Family. Is the Apple Account for this device already in an Apple Family?",
         primary: self.btn(text: "Yes, it’s in an Apple Family", .primary),
         secondary: self.btn(text: "No", .secondary),
         tertiary: self.btn(text: "I’m not sure", .tertiary)
@@ -67,32 +68,37 @@ struct AppView: View {
 
     case .onboarding(.happyPath(.explainTwoInstallSteps)):
       ButtonScreenView(
-        text: "Next we’ll authorize and install the content filter. It takes two steps, both of which are required.",
+        text:
+          "Next we’ll authorize and install the content filter. It takes two steps, both of which are required.",
         primary: self.btn(text: "Next", .primary)
       )
 
     case .onboarding(.happyPath(.explainAuthWithParentAppleAccount)):
       ButtonScreenView(
-        text: "For the first step, you’ll authorize Gertrude to access Screen Time using your Apple ID (the parent/guardian, not the child’s).",
+        text:
+          "For the first step, you’ll authorize Gertrude to access Screen Time using your Apple ID (the parent/guardian, not the child’s).",
         primary: self.btn(text: "Got it, next", .primary)
       )
 
     case .onboarding(.happyPath(.dontGetTrickedPreAuth)):
       ButtonScreenView(
-        text: "Don’t get tricked! Be sure to click “Allow”, even though it looks like you’re supposed to click “Don’t Allow”.",
-        primary: self.btn(text: "Got it, next", .primary),
+        text:
+          "Don’t get tricked! Be sure to click “Allow”, even though it looks like you’re supposed to click “Don’t Allow”.",
+        primary: self.btn(text: "Got it, next", .primary, animate: false, async: true),
         image: "AllowScreenTimeAccess"
       )
 
     case .onboarding(.happyPath(.explainInstallWithDevicePasscode)):
       ButtonScreenView(
-        text: "Great! Half way there. In the next step, use the passcode of this device (the one you’re holding), not your own.",
+        text:
+          "Great! Half way there. In the next step, use the passcode of this device (the one you’re holding), not your own.",
         primary: self.btn(text: "Got it, next", .primary)
       )
 
     case .onboarding(.happyPath(.dontGetTrickedPreInstall)):
       ButtonScreenView(
-        text: "Again, don’t get tricked! Be sure to click “Continue”, even though it looks like you’re supposed to click “Don’t Allow”.",
+        text:
+          "Again, don’t get tricked! Be sure to click “Continue”, even though it looks like you’re supposed to click “Don’t Allow”.",
         primary: self.btn(text: "Got it, next", .primary, animate: false),
         image: "AllowContentFilter"
       )
@@ -106,7 +112,8 @@ struct AppView: View {
 
     case .onboarding(.happyPath(.promptClearCache)):
       ButtonScreenView(
-        text: "Gertrude is now blocking new content, like when a new and unique search is made for GIFs. But content already viewed will still be visible unless we clear the cache.",
+        text:
+          "Gertrude is now blocking new content, like when a new and unique search is made for GIFs. But content already viewed will still be visible unless we clear the cache.",
         primary: self.btn(text: "Clear the cache", .primary),
         secondary: self.btn(text: "No need, skip", .secondary)
       )
@@ -131,7 +138,8 @@ struct AppView: View {
 
     case .onboarding(.happyPath(.requestAppStoreRating)):
       ButtonScreenView(
-        text: "All set! But, if you’d like to help other parents protect their kids, tap to give us a rating on the App Store.",
+        text:
+          "All set! But, if you’d like to help other parents protect their kids, tap to give us a rating on the App Store.",
         primary: self.btn(text: "Give a rating", .primary),
         secondary: self.btn(text: "Leave a review", .secondary),
         tertiary: self.btn(text: "No thanks", .tertiary),
@@ -150,7 +158,8 @@ struct AppView: View {
 
     case .onboarding(.authFail(.invalidAccount(.confirmInAppleFamily))):
       ButtonScreenView(
-        text: "It might be that the Apple Account is not part of an Apple Family. Apple won’t allow the installation if it’s not. Is the Apple Account a member of an Apple Family?",
+        text:
+          "It might be that the Apple Account is not part of an Apple Family. Apple won’t allow the installation if it’s not. Is the Apple Account a member of an Apple Family?",
         primary: self.btn(text: "Yes", .primary),
         secondary: self.btn(text: "No", .secondary),
         tertiary: self.btn(text: "I’m not sure", .tertiary),
@@ -159,7 +168,8 @@ struct AppView: View {
 
     case .onboarding(.authFail(.invalidAccount(.confirmIsMinor))):
       ButtonScreenView(
-        text: "Are you sure the birthday on the Apple Account is for someone under 18?\n\nGood to know: Apple does permit the birthday to be changed one time.",
+        text:
+          "Are you sure the birthday on the Apple Account is for someone under 18?\n\nGood to know: Apple does permit the birthday to be changed one time.",
         primary: self.btn(text: "Age is 18 or over", .primary),
         secondary: self.btn(text: "Age is under 18", .secondary),
         screenType: .error
@@ -167,14 +177,16 @@ struct AppView: View {
 
     case .onboarding(.authFail(.invalidAccount(.unexpected))):
       ButtonScreenView(
-        text: "Well gosh, we’re not sure what’s wrong then. Try powering the device off completely, then start the installation again. If you get here again, please contact us for more help using the link below.",
+        text:
+          "Well gosh, we’re not sure what’s wrong then. Try powering the device off completely, then start the installation again. If you get here again, please contact us for more help using the link below.",
         primary: .init(text: "Contact us", type: .link(.support), animate: false),
         screenType: .error
       )
 
     case .onboarding(.authFail(.authCanceled)):
       ButtonScreenView(
-        text: "Whoops! Looks like you either clicked the wrong button, or canceled the process mid-way. No problem, we’ll just try again.",
+        text:
+          "Whoops! Looks like you either clicked the wrong button, or canceled the process mid-way. No problem, we’ll just try again.",
         primary: self.btn(text: "Try again", .primary),
         secondary: .init(text: "Contact us", type: .link(.support), animate: false),
         screenType: .error
@@ -182,35 +194,40 @@ struct AppView: View {
 
     case .onboarding(.authFail(.restricted)):
       ButtonScreenView(
-        text: "A restriction is preventing Gertrude from being installed. Is this device is enrolled in mobile device management (MDM) by an organization or school? If so, try again on a device not managed by MDM.",
+        text:
+          "A restriction is preventing Gertrude from being installed. Is this device is enrolled in mobile device management (MDM) by an organization or school? If so, try again on a device not managed by MDM.",
         primary: .init(text: "Contact support", type: .link(.support), animate: false),
         screenType: .error
       )
 
     case .onboarding(.authFail(.authConflict)):
       ButtonScreenView(
-        text: "We got an error that there was a conflict with another parental controls app. If you know what that might be and can remove it, do so and then try again.",
+        text:
+          "We got an error that there was a conflict with another parental controls app. If you know what that might be and can remove it, do so and then try again.",
         primary: self.btn(text: "Done, continue", .primary),
         screenType: .error
       )
 
     case .onboarding(.authFail(.networkError)):
       ButtonScreenView(
-        text: "Hmmm.. Are you sure you’re connected to the internet? Double-check and try again when you’re online.",
+        text:
+          "Hmmm.. Are you sure you’re connected to the internet? Double-check and try again when you’re online.",
         primary: self.btn(text: "Try again", .primary),
         screenType: .error
       )
 
     case .onboarding(.authFail(.passcodeRequired)):
       ButtonScreenView(
-        text: "Sorry, Apple won’t let us install unless this device has a passcode set. Go to the Settings app and set one up, then try again.",
+        text:
+          "Sorry, Apple won’t let us install unless this device has a passcode set. Go to the Settings app and set one up, then try again.",
         primary: self.btn(text: "Try again", .primary),
         screenType: .error
       )
 
     case .onboarding(.authFail(.unexpected)):
       ButtonScreenView(
-        text: "Shucks, something went wrong, but we’re not exactly sure what. Please try again, and if you end up here again, contact us for help.",
+        text:
+          "Shucks, something went wrong, but we’re not exactly sure what. Please try again, and if you end up here again, contact us for help.",
         primary: self.btn(text: "Try again", .primary),
         secondary: .init(text: "Contact us", type: .link(.support), animate: false),
         screenType: .error
@@ -218,7 +235,8 @@ struct AppView: View {
 
     case .onboarding(.installFail(.permissionDenied)):
       ButtonScreenView(
-        text: "Whoops! Looks like you either clicked the wrong button, or canceled the process mid-way. No problem, we’ll just try again.",
+        text:
+          "Whoops! Looks like you either clicked the wrong button, or canceled the process mid-way. No problem, we’ll just try again.",
         primary: self.btn(text: "Try again", .primary),
         secondary: .init(text: "Contact us", type: .link(.support), animate: false),
         screenType: .error
@@ -226,7 +244,8 @@ struct AppView: View {
 
     case .onboarding(.installFail(.other)):
       ButtonScreenView(
-        text: "Shucks, something went wrong, but we’re not exactly sure what. Please try again, and if you end up here again, contact us for help.",
+        text:
+          "Shucks, something went wrong, but we’re not exactly sure what. Please try again, and if you end up here again, contact us for help.",
         primary: self.btn(text: "Try again", .primary),
         secondary: .init(text: "Contact us", type: .link(.support), animate: false),
         screenType: .error
@@ -234,18 +253,21 @@ struct AppView: View {
 
     case .onboarding(.onParentDeviceFail):
       ButtonScreenView(
-        text: "Gertrude must be installed on the device you want to protect, not on a parent or guardian’s device. Delete the app and start over by installing it on the device you want to protect."
+        text:
+          "Gertrude must be installed on the device you want to protect, not on a parent or guardian’s device. Delete the app and start over by installing it on the device you want to protect."
       )
 
     case .onboarding(.childIsOnboardingFail):
       ButtonScreenView(
-        text: "Setting up Gertrude requires your parent or guardian. Give your device to them so they can finish the setup.",
+        text:
+          "Setting up Gertrude requires your parent or guardian. Give your device to them so they can finish the setup.",
         primary: self.btn(text: "Done, continue", .primary)
       )
 
     case .onboarding(.major(.explainHarderButPossible)):
       ButtonScreenView(
-        text: "Getting this app working on the device of someone over 18 is harder, but still possible. We’ll walk you through all the steps.",
+        text:
+          "Getting this app working on the device of someone over 18 is harder, but still possible. We’ll walk you through all the steps.",
         primary: self.btn(text: "Next", .primary)
       )
 
@@ -266,7 +288,8 @@ struct AppView: View {
 
     case .onboarding(.major(.explainFixAccountTypeEasyWay)):
       ButtonScreenView(
-        text: "The easiest way to make this work is to get this device signed into an Apple Account that is part of an Apple Family, with a birthday less than 18 years ago. If you can, do that now, then start the installation again, and the setup will be easy.\n\nHow can you do this?",
+        text:
+          "The easiest way to make this work is to get this device signed into an Apple Account that is part of an Apple Family, with a birthday less than 18 years ago. If you can, do that now, then start the installation again, and the setup will be easy.\n\nHow can you do this?",
         primary: self.btn(text: "Done", .primary),
         secondary: self.btn(text: "Is there another way?", .secondary),
         listItems: [
@@ -284,7 +307,7 @@ struct AppView: View {
       )
 
     case .onboarding(.major(.askIfInAppleFamily)),
-         .onboarding(.major(.explainAppleFamily)):
+      .onboarding(.major(.explainAppleFamily)):
       ButtonScreenView(
         text: "Are you in an Apple Family, or could you join one?",
         primary: self.btn(text: "Yes", .primary),
@@ -295,7 +318,8 @@ struct AppView: View {
         ZStack {
           Color(cs, light: .clear, dark: .black).ignoresSafeArea(edges: .all)
           ButtonScreenView(
-            text: "An Apple Family group allows sharing of apps and services. There’s no cost, and it’s easy to set one up. You would need someone else to start a group (if they didn’t already have one) and then invite you to join.",
+            text:
+              "An Apple Family group allows sharing of apps and services. There’s no cost, and it’s easy to set one up. You would need someone else to start a group (if they didn’t already have one) and then invite you to join.",
             primary: .init(text: "Instructions", type: .link(.appleFamily), animate: false),
             secondary: self.btn(text: "Continue", .primary, animate: false)
           )
@@ -305,7 +329,8 @@ struct AppView: View {
 
     case .onboarding(.appleFamily(.explainRequiredForFiltering)):
       ButtonScreenView(
-        text: "Sorry, Apple doesn’t allow a content blocker to be installed on a device that’s not in an Apple Family.",
+        text:
+          "Sorry, Apple doesn’t allow a content blocker to be installed on a device that’s not in an Apple Family.",
         primary: self.btn(text: "Next", .primary)
       )
 
@@ -329,13 +354,15 @@ struct AppView: View {
 
     case .onboarding(.appleFamily(.explainWhatIsAppleFamily)):
       ButtonScreenView(
-        text: "An Apple Family group allows sharing of apps and services, plus it gives parents additional controls over their kids devices. There’s no cost, and it’s easy to set one up.",
+        text:
+          "An Apple Family group allows sharing of apps and services, plus it gives parents additional controls over their kids devices. There’s no cost, and it’s easy to set one up.",
         primary: self.btn(text: "Next", .primary)
       )
 
     case .onboarding(.appleFamily(.checkIfInAppleFamily)):
       ButtonScreenView(
-        text: "You can check if you’re already setup by opening the “Settings” app on this device. If you see a “Family” section right below the Apple Account name and picture, you’re already set.",
+        text:
+          "You can check if you’re already setup by opening the “Settings” app on this device. If you see a “Family” section right below the Apple Account name and picture, you’re already set.",
         primary: self.btn(text: "Yes, in a family", .primary),
         secondary: self.btn(text: "Not in a family yet", .secondary)
       )
@@ -348,20 +375,23 @@ struct AppView: View {
 
     case .onboarding(.supervision(.explainSupervision)):
       ButtonScreenView(
-        text: "Supervised mode is most often used for devices owned by schools or businesses, and it enables many additional options and restrictions.",
+        text:
+          "Supervised mode is most often used for devices owned by schools or businesses, and it enables many additional options and restrictions.",
         primary: self.btn(text: "Next", .primary)
       )
 
     case .onboarding(.supervision(.explainNeedFriendWithMac)):
       ButtonScreenView(
-        text: "For supervised mode, you’ll need a trusted friend with a Mac computer to be your administrator. They don’t have to live with you, but they will need physical access to your device to set it up and from time to time after that.",
+        text:
+          "For supervised mode, you’ll need a trusted friend with a Mac computer to be your administrator. They don’t have to live with you, but they will need physical access to your device to set it up and from time to time after that.",
         primary: self.btn(text: "I’ve got someone", .primary),
         secondary: self.btn(text: "I don’t have anyone", .secondary)
       )
 
     case .onboarding(.supervision(.explainRequiresEraseAndSetup)):
       ButtonScreenView(
-        text: "Setting up supervised mode requires temporarily erasing the device, an administrator with a Mac computer, and about an hour of work. You can restore the content and settings afterwards.",
+        text:
+          "Setting up supervised mode requires temporarily erasing the device, an administrator with a Mac computer, and about an hour of work. You can restore the content and settings afterwards.",
         primary: self.btn(text: "Show me how", .primary),
         secondary: self.btn(text: "No thanks", .secondary)
       )
@@ -379,12 +409,14 @@ struct AppView: View {
 
     case .onboarding(.supervision(.sorryNoOtherWay)):
       ButtonScreenView(
-        text: "Sorry, looks like Gertrude won’t be able to help you with this device. Unfortunately we can only install the content blocker when Apple allows us, which is only for a child’s device or a supervised device."
+        text:
+          "Sorry, looks like Gertrude won’t be able to help you with this device. Unfortunately we can only install the content blocker when Apple allows us, which is only for a child’s device or a supervised device."
       )
 
     case .supervisionSuccessFirstLaunch:
       ButtonScreenView(
-        text: "Excellent! Looks like you’ve installed Gertrude under Supervised mode. Just a couple steps to get you all set up.",
+        text:
+          "Excellent! Looks like you’ve installed Gertrude under Supervised mode. Just a couple steps to get you all set up.",
         primary: self.btn(text: "Next", .primary)
       )
 
@@ -400,8 +432,13 @@ struct AppView: View {
     )
   }
 
-  func btn(text: String, _ type: ButtonType, animate: Bool = true) -> ButtonScreenView.Config {
-    .init(text, animate: animate) {
+  func btn(
+    text: String,
+    _ type: ButtonType,
+    animate: Bool = true,
+    async: Bool = false
+  ) -> ButtonScreenView.Config {
+    .init(text, animate: animate, asyncAction: async) {
       switch type {
       case .primary:
         self.store.send(.interactive(.onboardingBtnTapped(.primary, text)))

--- a/iosapp/app/Views/BigButton.swift
+++ b/iosapp/app/Views/BigButton.swift
@@ -7,6 +7,7 @@ struct BigButton: View {
   var type: ButtonType
   var variant: Variant
   var icon: String?
+  var disabled: Bool
 
   var label: some View {
     HStack {
@@ -14,40 +15,49 @@ struct BigButton: View {
       Text(self.text)
         .font(.system(size: 18, weight: .semibold))
         .foregroundStyle(
-          self.variant == .primary ? Color(self.cs, light: .white, dark: .white) :
-            Color(self.cs, light: .violet500, dark: .violet400)
+          self.variant == .primary
+            ? Color(self.cs, light: .white, dark: .white)
+            : Color(self.cs, light: .violet500, dark: .violet400)
         )
       if let icon = self.icon {
         Image(systemName: icon)
           .font(.system(size: 16, weight: .semibold))
           .foregroundStyle(
-            self.variant == .primary ? Color(self.cs, light: .white, dark: .white) :
-              Color(self.cs, light: .violet500, dark: .violet400)
+            self.variant == .primary
+              ? Color(self.cs, light: .white, dark: .white)
+              : Color(self.cs, light: .violet500, dark: .violet400)
           )
       }
       Spacer()
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 14)
-    .background(self.variant == .primary ? Color(
-      self.cs,
-      light: .violet500,
-      dark:
-      .violet600.opacity(0.9)
-    ) : Color(
-      self.cs,
-      light: .violet500.opacity(0.1),
-      dark:
-      .violet500.opacity(0.15)
-    ))
+    .background(
+      self.variant == .primary
+        ? Color(
+          self.cs,
+          light: .violet500,
+          dark:
+            .violet600.opacity(0.9)
+        )
+        : Color(
+          self.cs,
+          light: .violet500.opacity(0.1),
+          dark:
+            .violet500.opacity(0.15)
+        )
+    )
     .cornerRadius(16)
+    .opacity(self.disabled ? 0.5 : 1)
   }
 
   var body: some View {
     switch self.type {
     case .button(let onTap):
       Button {
-        onTap()
+        if !self.disabled {
+          onTap()
+        }
       } label: {
         self.label
       }
@@ -62,11 +72,18 @@ struct BigButton: View {
     }
   }
 
-  init(_ text: String, type: ButtonType, variant: Variant, icon: String? = nil) {
+  init(
+    _ text: String,
+    type: ButtonType,
+    variant: Variant,
+    icon: String? = nil,
+    disabled: Bool = false
+  ) {
     self.text = text
     self.type = type
     self.variant = variant
     self.icon = icon
+    self.disabled = disabled
   }
 
   enum Variant {
@@ -87,6 +104,16 @@ struct BigButton: View {
     BigButton("Click me", type: .button {}, variant: .secondary)
     BigButton("Click me", type: .button {}, variant: .primary, icon: "plus")
     BigButton("Click me", type: .button {}, variant: .secondary, icon: "plus")
+  }
+  .padding(20)
+}
+
+#Preview(".button (disabled)") {
+  VStack(spacing: 20) {
+    BigButton("Click me", type: .button {}, variant: .primary, disabled: true)
+    BigButton("Click me", type: .button {}, variant: .secondary, disabled: true)
+    BigButton("Click me", type: .button {}, variant: .primary, icon: "plus", disabled: true)
+    BigButton("Click me", type: .button {}, variant: .secondary, icon: "plus", disabled: true)
   }
   .padding(20)
 }

--- a/iosapp/app/Views/ChooseWhatToBlockView.swift
+++ b/iosapp/app/Views/ChooseWhatToBlockView.swift
@@ -56,18 +56,23 @@ struct ChooseWhatToBlockView: View {
 
         self.selectableGroups
 
-        BigButton("Done, continue", type: .button {
-          self.vanishingAnimations()
-          delayed(by: .seconds(0.5)) {
-            self.onDone()
-          }
-        }, variant: .primary)
-          .swooshIn(
-            tracking: self.$buttonOffset,
-            to: .zero,
-            after: .seconds(0.2),
-            for: .seconds(0.6)
-          )
+        BigButton(
+          "Done, continue",
+          type: .button {
+            self.vanishingAnimations()
+            delayed(by: .seconds(0.5)) {
+              self.onDone()
+            }
+          },
+          variant: .primary,
+          disabled: self.deselectedGroups == .all
+        )
+        .swooshIn(
+          tracking: self.$buttonOffset,
+          to: .zero,
+          after: .seconds(0.2),
+          for: .seconds(0.6)
+        )
       }
       .frame(maxWidth: 500)
       .padding(.top, 100)
@@ -104,11 +109,13 @@ struct ChooseWhatToBlockView: View {
               .padding(.bottom, 4)
             Text(item.longDescription)
               .font(.system(size: 16))
-              .foregroundStyle(Color(
-                self.cs,
-                light: .black.opacity(0.7),
-                dark: .white.opacity(0.7)
-              ))
+              .foregroundStyle(
+                Color(
+                  self.cs,
+                  light: .black.opacity(0.7),
+                  dark: .white.opacity(0.7)
+                )
+              )
               .multilineTextAlignment(.center)
           }
           .presentationDetents([.height(600)])
@@ -120,17 +127,21 @@ struct ChooseWhatToBlockView: View {
               } label: {
                 Image(systemName: "xmark")
                   .font(.system(size: 10, weight: .bold))
-                  .foregroundStyle(Color(
-                    self.cs,
-                    light: .black.opacity(0.4),
-                    dark: .white.opacity(0.5)
-                  ))
+                  .foregroundStyle(
+                    Color(
+                      self.cs,
+                      light: .black.opacity(0.4),
+                      dark: .white.opacity(0.5)
+                    )
+                  )
                   .padding(8)
-                  .background(Color(
-                    self.cs,
-                    light: .black.opacity(0.05),
-                    dark: .white.opacity(0.08)
-                  ))
+                  .background(
+                    Color(
+                      self.cs,
+                      light: .black.opacity(0.05),
+                      dark: .white.opacity(0.08)
+                    )
+                  )
                   .cornerRadius(16)
               }
             }
@@ -155,11 +166,15 @@ struct ChooseWhatToBlockView: View {
                 .scaleEffect(self.isSelected(item) ? 1 : 0)
                 .foregroundStyle(.white)
                 .padding(4)
-                .background(self.isSelected(item) ? Color.violet500 : Color(
-                  self.cs,
-                  light: .white,
-                  dark: .black
-                ))
+                .background(
+                  self.isSelected(item)
+                    ? Color.violet500
+                    : Color(
+                      self.cs,
+                      light: .white,
+                      dark: .black
+                    )
+                )
                 .cornerRadius(6)
                 .overlay {
                   RoundedRectangle(cornerRadius: 6)
@@ -183,11 +198,13 @@ struct ChooseWhatToBlockView: View {
                   } label: {
                     Image(systemName: "questionmark.circle")
                       .font(.system(size: 12, weight: .medium))
-                      .foregroundStyle(Color(
-                        self.cs,
-                        light: .black.opacity(0.4),
-                        dark: .white.opacity(0.4)
-                      ))
+                      .foregroundStyle(
+                        Color(
+                          self.cs,
+                          light: .black.opacity(0.4),
+                          dark: .white.opacity(0.4)
+                        )
+                      )
                       .padding(.horizontal, 8)
                       .padding(.vertical, 4)
                       .multilineTextAlignment(.leading)
@@ -196,21 +213,25 @@ struct ChooseWhatToBlockView: View {
 
                 Text(item.shortDescription)
                   .font(.system(size: 15, weight: .regular))
-                  .foregroundStyle(Color(
-                    self.cs,
-                    light: .black.opacity(0.6),
-                    dark: .white.opacity(0.6)
-                  ))
+                  .foregroundStyle(
+                    Color(
+                      self.cs,
+                      light: .black.opacity(0.6),
+                      dark: .white.opacity(0.6)
+                    )
+                  )
                   .frame(maxWidth: .infinity, alignment: .leading)
               }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 12)
             .padding(.vertical, 12)
-            .background(Gradient(colors: [
-              Color(self.cs, light: .white, dark: .white.opacity(0.15)),
-              Color(self.cs, light: .white.opacity(0.7), dark: .white.opacity(0.07)),
-            ]))
+            .background(
+              Gradient(colors: [
+                Color(self.cs, light: .white, dark: .white.opacity(0.15)),
+                Color(self.cs, light: .white.opacity(0.7), dark: .white.opacity(0.07)),
+              ])
+            )
             .cornerRadius(16)
             .shadow(
               color: Color(self.cs, light: .violet200, dark: .violet900.opacity(0.3)),
@@ -332,20 +353,32 @@ extension BlockGroup {
 
   var longDescription: String {
     switch self {
-    case .ads: "Blocks the 20 most common ad providers, including Google ads, in all browsers and apps. Does not guarantee to block all ads, but should make a noticeable difference."
-    case .aiFeatures: "Blocks certain cloud-based AI features like image recognition. For example, the iOS 18 feature where an item in a photo can be long-pressed, identified, and searched for online."
-    case .appStoreImages: "Eliminates all images for apps in the App Store, and in other places where the App Store appears, like in the Messages texting app."
-    case .appleMapsImages: "Apple Maps business listings show photos uploaded by customers and businesses, and for certain types of businesses, these can be explicit. This group blocks all images from within Apple Maps."
-    case .appleWebsite: "Certain parts of iOS (including the Settings app) contain links to the apple.com website. It is possible to view these pages and from there follow links to other parts of the web. This group blocks this access."
-    case .gifs: "Blocks viewing and searching for GIFs in the #images feature of Apple’s texting app, plus in other common messaging apps like WhatsApp, Skype, and Signal."
-    case .spotlightSearches: "The built in search bar in iOS (called Spotlight) allows searching for information and images from the internet. This group stops all spotlight internet searches. Local information are still permitted."
-    case .whatsAppFeatures: "This group attempts to block some of aspects of the WhatsApp app, including the media channels. It is experimental, and does not guarantee by any means that the app will be safe for children, but it does reduce some risks."
+    case .ads:
+      "Blocks the 20 most common ad providers, including Google ads, in all browsers and apps. Does not guarantee to block all ads, but should make a noticeable difference."
+    case .aiFeatures:
+      "Blocks certain cloud-based AI features like image recognition. For example, the iOS 18 feature where an item in a photo can be long-pressed, identified, and searched for online."
+    case .appStoreImages:
+      "Eliminates all images for apps in the App Store, and in other places where the App Store appears, like in the Messages texting app."
+    case .appleMapsImages:
+      "Apple Maps business listings show photos uploaded by customers and businesses, and for certain types of businesses, these can be explicit. This group blocks all images from within Apple Maps."
+    case .appleWebsite:
+      "Certain parts of iOS (including the Settings app) contain links to the apple.com website. It is possible to view these pages and from there follow links to other parts of the web. This group blocks this access."
+    case .gifs:
+      "Blocks viewing and searching for GIFs in the #images feature of Apple’s texting app, plus in other common messaging apps like WhatsApp, Skype, and Signal."
+    case .spotlightSearches:
+      "The built in search bar in iOS (called Spotlight) allows searching for information and images from the internet. This group stops all spotlight internet searches. Local information are still permitted."
+    case .whatsAppFeatures:
+      "This group attempts to block some of aspects of the WhatsApp app, including the media channels. It is experimental, and does not guarantee by any means that the app will be safe for children, but it does reduce some risks."
     }
   }
 }
 
-#Preview {
+#Preview("none selected") {
   ChooseWhatToBlockView(deselectedGroups: .all, onGroupToggle: { _ in }) {}
+}
+
+#Preview("all selected") {
+  ChooseWhatToBlockView(deselectedGroups: [], onGroupToggle: { _ in }) {}
 }
 
 struct BounceButtonStyle: ButtonStyle {

--- a/iosapp/app/Views/RunningView.swift
+++ b/iosapp/app/Views/RunningView.swift
@@ -54,9 +54,18 @@ struct RunningView: View {
             for: .seconds(0.5)
           )
 
+        Link(destination: URL(string: "https://gertrude.app")!) {
+          HStack {
+            Text("www.gertrude.app")
+            Image(systemName: "arrow.up.right")
+              .font(.system(size: 14, weight: .semibold))
+              .offset(y: 1.5)
+          }
+        }
+        .padding(.top, 25)
+
         Text("\(self.device.vendorId?.uuidString.lowercased() ?? "unknown")")
           .font(.system(size: 11, design: .monospaced))
-          .foregroundStyle(.black)
           .opacity(self.showVendorId ? 1 : 0)
           .padding(.top, 25)
 

--- a/x-expect/Package.resolved
+++ b/x-expect/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "ad86bb2e59c1491d0c90e57bf7cf38079ced0efa6b5e312d402b9ce19ab43417",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "aec6a73f5c1dc1f1be4f61888094b95cf995d973",
+        "version" : "1.3.2"
       }
     },
     {
@@ -14,10 +15,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
- adds link to running screen
- disables the "done" button if all of the blocking options are deselected
- slight fixes to vender id (didn't work on dark mode)
- added `asyncAction` parameter to button screens and used it for auth step