### PR TITLE
format, lint xml files to reduce diff churn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: test
         run: cd iosapp/lib-ios && swift test
 
-  swiftformat:
+  swift-lint:
     if: github.event_name == 'pull_request'
     runs-on: namespace-profile-default
     container: swift:6.0.3-focal
@@ -242,8 +242,21 @@ jobs:
           cd SwiftFormat && swift build -c debug
           cp ./.build/debug/swiftformat /usr/local/bin
           cd ../ && rm -rf SwiftFormat/
-      - name: lint
+      - name: swiftlint
         run: swiftformat . --lint
+
+  xml-lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup just
+        uses: extractions/setup-just@v2
+      - name: install
+        run: cargo install xml-lint
+      - name: xml-lint
+        run: just lint-xml
 
 # env
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
   files-changed:
     if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     outputs:
       macapp: ${{ steps.changes.outputs.macapp }}
       iosapp: ${{ steps.changes.outputs.iosapp }}
@@ -231,7 +231,7 @@ jobs:
 
   swift-lint:
     if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     container: swift:6.0.3-focal
     steps:
       - name: checkout

--- a/iosapp/app/Info.plist
+++ b/iosapp/app/Info.plist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>UILaunchScreen</key>
   <dict>
-    <key>UIColorName</key>
-    <string>white</string>
-    <key>UIImageName</key>
-    <string>GertrudeIcon</string>
+    <key>UILaunchScreen</key>
+    <dict>
+      <key>UIColorName</key>
+      <string>white</string>
+      <key>UIImageName</key>
+      <string>GertrudeIcon</string>
+    </dict>
   </dict>
-</dict>
 </plist>

--- a/iosapp/app/app.entitlements
+++ b/iosapp/app/app.entitlements
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>com.apple.developer.family-controls</key>
-  <true/>
-  <key>com.apple.developer.networking.networkextension</key>
-  <array>
-    <string>content-filter-provider</string>
-  </array>
-  <key>com.apple.security.application-groups</key>
-  <array>
-    <string>group.com.netrivet.gertrude-ios.app</string>
-  </array>
-</dict>
+  <dict>
+    <key>com.apple.developer.family-controls</key>
+    <true/>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>content-filter-provider</string>
+    </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.com.netrivet.gertrude-ios.app</string>
+    </array>
+  </dict>
 </plist>

--- a/iosapp/controller/Info.plist
+++ b/iosapp/controller/Info.plist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.networkextension.filter-control</string>
-		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).FilterControlProvider</string>
-	</dict>
-</dict>
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.networkextension.filter-control</string>
+      <key>NSExtensionPrincipalClass</key>
+      <string>$(PRODUCT_MODULE_NAME).FilterControlProvider</string>
+    </dict>
+  </dict>
 </plist>

--- a/iosapp/controller/controller.entitlements
+++ b/iosapp/controller/controller.entitlements
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>com.apple.developer.networking.networkextension</key>
-  <array>
-    <string>content-filter-provider</string>
-  </array>
-  <key>com.apple.security.application-groups</key>
-  <array>
-    <string>group.com.netrivet.gertrude-ios.app</string>
-  </array>
-</dict>
+  <dict>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>content-filter-provider</string>
+    </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.com.netrivet.gertrude-ios.app</string>
+    </array>
+  </dict>
 </plist>

--- a/iosapp/filter/Info.plist
+++ b/iosapp/filter/Info.plist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.networkextension.filter-data</string>
-		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).FilterDataProvider</string>
-	</dict>
-</dict>
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.networkextension.filter-data</string>
+      <key>NSExtensionPrincipalClass</key>
+      <string>$(PRODUCT_MODULE_NAME).FilterDataProvider</string>
+    </dict>
+  </dict>
 </plist>

--- a/iosapp/filter/filter.entitlements
+++ b/iosapp/filter/filter.entitlements
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>com.apple.developer.networking.networkextension</key>
-  <array>
-    <string>content-filter-provider</string>
-  </array>
-  <key>com.apple.security.application-groups</key>
-  <array>
-    <string>group.com.netrivet.gertrude-ios.app</string>
-  </array>
-</dict>
+  <dict>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>content-filter-provider</string>
+    </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.com.netrivet.gertrude-ios.app</string>
+    </array>
+  </dict>
 </plist>

--- a/justfile
+++ b/justfile
@@ -89,11 +89,25 @@ build:
 test:
   @just nx-run-many test
 
-lint:
+lint-swift:
   @swiftformat . --lint
 
-lint-fix:
+lint-swift-fix:
   @swiftformat .
+
+lint-xml:
+  @xml-lint {{xmlfiles}}
+
+lint-xml-fix:
+  @xml-lint --fix {{xmlfiles}}
+
+lint:
+  @just lint-swift
+  @just lint-xml
+
+lint-fix:
+  @just lint-swift-fix
+  @just lint-xml-fix
 
 check:
   @just build
@@ -134,3 +148,19 @@ watch-test dir isolate="":
   @just watch-swift {{dir}} '"cd {{dir}} && \
   SWIFT_DETERMINISTIC_HASHING=1 swift test \
   {{ if isolate != "" { "--filter " + isolate } else { "" } }} "'
+
+# variables
+
+xmlfiles := """
+./iosapp/app/app.entitlements \
+./iosapp/app/Info.plist \
+./iosapp/controller/controller.entitlements \
+./iosapp/controller/Info.plist \
+./iosapp/filter/filter.entitlements \
+./iosapp/filter/Info.plist \
+./macapp/Xcode/GertrudeFilterExtension/GertrudeFilterExtension.entitlements \
+./macapp/Xcode/GertrudeFilterExtension/Info.plist \
+./macapp/Xcode/Gertrude/Gertrude.entitlements \
+./macapp/Xcode/Gertrude/Info.plist \
+./macapp/Xcode/GertrudeRelauncher/GertrudeRelauncher.entitlements
+"""

--- a/macapp/Xcode/Gertrude/Gertrude.entitlements
+++ b/macapp/Xcode/Gertrude/Gertrude.entitlements
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.networking.networkextension</key>
-	<array>
-		<string>content-filter-provider-systemextension</string>
-	</array>
-	<key>com.apple.developer.system-extension.install</key>
-	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>$(TeamIdentifierPrefix)com.netrivet.gertrude.group</string>
-	</array>
-</dict>
+  <dict>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>content-filter-provider-systemextension</string>
+    </array>
+    <key>com.apple.developer.system-extension.install</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>$(TeamIdentifierPrefix)com.netrivet.gertrude.group</string>
+    </array>
+  </dict>
 </plist>

--- a/macapp/Xcode/Gertrude/Info.plist
+++ b/macapp/Xcode/Gertrude/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIconFile</key>
-    <string></string>
+    <string/>
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleInfoDictionaryVersion</key>
@@ -23,15 +23,15 @@
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
-    <true />
+    <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2023 NetRivet Inc. All rights reserved.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSSupportsAutomaticTermination</key>
-    <true />
+    <true/>
     <key>NSSupportsSuddenTermination</key>
-    <true />
+    <true/>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.utilities</string>
     <key>SUPublicEDKey</key>
@@ -41,7 +41,7 @@
     <key>NSAppTransportSecurity</key>
     <dict>
       <key>NSAllowsLocalNetworking</key>
-      <true />
+      <true/>
     </dict>
   </dict>
 </plist>

--- a/macapp/Xcode/GertrudeFilterExtension/GertrudeFilterExtension.entitlements
+++ b/macapp/Xcode/GertrudeFilterExtension/GertrudeFilterExtension.entitlements
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.networking.networkextension</key>
-	<array>
-		<string>content-filter-provider-systemextension</string>
-	</array>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>$(TeamIdentifierPrefix)com.netrivet.gertrude.group</string>
-	</array>
-</dict>
+  <dict>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>content-filter-provider-systemextension</string>
+    </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>$(TeamIdentifierPrefix)com.netrivet.gertrude.group</string>
+    </array>
+  </dict>
 </plist>

--- a/macapp/Xcode/GertrudeRelauncher/GertrudeRelauncher.entitlements
+++ b/macapp/Xcode/GertrudeRelauncher/GertrudeRelauncher.entitlements
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-  <key>com.apple.security.inherit</key>
-  <true/>
-</dict>
+  <dict>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
 </plist>


### PR DESCRIPTION
This PR solves a little papercut that is only going to get worse as we have more people working in the monorepo, especially with different editors, and that is the formatting of the `*.plist` and `*.entitlements` xml files.

This introduces a new just command to lint and fix all the xml files, and incorporates it into the CI pipeline as well. I couldn't find exactly the tool I wanted, so I quick whipped up a little rust crate and open-sourced it on in our Gertrude org here:

https://github.com/gertrude-app/xml-lint

To install it for local use, you'll need to do `cargo install xml-lint` (@chriswoolfe if you don't have a rust toolchain installed, check the docs, it's super easy, just `curl https://sh.rustup.rs -sSf | sh`, the whole tooling ecosystem in rust is superb).  We can now also run `just lint-fix` locally now and it will fix swift and xml files, and CI will catch any failures to format.

I'm starting to think long-term it might be nice to get some pre-commit hooks (maybe with something like husky?) so that all of our commits are cleaner and we have to think less about formatting things, but this is at least a quick win and a step in that direction.