### PR TITLE
api: merge ios screenshots with macos for dashboard

### DIFF
--- a/api/Sources/Api/Models/User/User.swift
+++ b/api/Sources/Api/Models/User/User.swift
@@ -40,8 +40,14 @@ struct User: Codable, Sendable {
 // loaders
 
 extension User {
-  func devices(in db: any DuetSQL.Client) async throws -> [UserDevice] {
+  func computerUsers(in db: any DuetSQL.Client) async throws -> [UserDevice] {
     try await UserDevice.query()
+      .where(.childId == self.id)
+      .all(in: db)
+  }
+
+  func iosDevices(in db: any DuetSQL.Client) async throws -> [IOSApp.Device] {
+    try await IOSApp.Device.query()
       .where(.childId == self.id)
       .all(in: db)
   }

--- a/api/Sources/Api/PairQL/Dashboard/Pairs/CombinedUsersActivityFeed.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/CombinedUsersActivityFeed.swift
@@ -27,12 +27,13 @@ extension CombinedUsersActivityFeed: Resolver {
       throw Abort(.badRequest)
     }
 
-    let users = try await context.users()
+    let children = try await context.users()
 
-    return try await users.concurrentMap { user in
-      let userDeviceIds = try await user.devices(in: context.db).map(\.id)
+    return try await children.concurrentMap { child in
+      let computerUserIds = try await child.computerUsers(in: context.db).map(\.id)
+      let iosDeviceIds = try await child.iosDevices(in: context.db).map(\.id)
       async let keystrokes = KeystrokeLine.query()
-        .where(.computerUserId |=| userDeviceIds)
+        .where(.computerUserId |=| computerUserIds)
         .where(.createdAt <= .date(before))
         .where(.createdAt > .date(after))
         .orderBy(.createdAt, .desc)
@@ -40,7 +41,7 @@ extension CombinedUsersActivityFeed: Resolver {
         .all(in: context.db)
 
       async let screenshots = Screenshot.query()
-        .where(.computerUserId |=| userDeviceIds)
+        .where(.or(.computerUserId |=| computerUserIds, .iosDeviceId |=| iosDeviceIds))
         .where(.createdAt <= .date(before))
         .where(.createdAt > .date(after))
         .orderBy(.createdAt, .desc)
@@ -50,8 +51,8 @@ extension CombinedUsersActivityFeed: Resolver {
       let coalesced = try await coalesce(screenshots, keystrokes)
 
       return UserDay(
-        userName: user.name,
-        showSuspensionActivity: user.showSuspensionActivity,
+        userName: child.name,
+        showSuspensionActivity: child.showSuspensionActivity,
         numDeleted: coalesced.lazy.filter(\.isDeleted).count,
         items: coalesced.lazy.filter(\.notDeleted)
       )

--- a/api/Sources/Api/PairQL/Dashboard/Pairs/GetAdmin.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/GetAdmin.swift
@@ -43,7 +43,7 @@ extension GetAdmin: NoInputResolver {
     async let notifications = admin.notifications(in: context.db)
     async let methods = admin.verifiedNotificationMethods(in: context.db)
     async let hasAdminChild = try await admin.users(in: context.db)
-      .concurrentMap { try await $0.devices(in: context.db) }
+      .concurrentMap { try await $0.computerUsers(in: context.db) }
       .flatMap(\.self)
       .contains { $0.isAdmin == true }
 

--- a/api/Sources/Api/PairQL/Dashboard/Pairs/GetUserUnlockRequests.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/GetUserUnlockRequests.swift
@@ -12,7 +12,7 @@ struct GetUserUnlockRequests: Pair {
 extension GetUserUnlockRequests: Resolver {
   static func resolve(with id: User.Id, in context: AdminContext) async throws -> Output {
     let user = try await context.verifiedUser(from: id)
-    let userDevices = try await user.devices(in: context.db)
+    let userDevices = try await user.computerUsers(in: context.db)
     let requests = try await UnlockRequest.query()
       .where(.computerUserId |=| userDevices.map { .id($0) })
       .all(in: context.db)

--- a/api/Sources/Api/PairQL/Dashboard/Pairs/UserActivityFeed.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/UserActivityFeed.swift
@@ -65,11 +65,12 @@ extension UserActivityFeed: Resolver {
       throw Abort(.badRequest)
     }
 
-    let user = try await context.verifiedUser(from: input.userId)
-    let userDeviceIds = try await user.devices(in: context.db).map(\.id)
+    let child = try await context.verifiedUser(from: input.userId)
+    let computerUserIds = try await child.computerUsers(in: context.db).map(\.id)
+    let iosDeviceIds = try await child.iosDevices(in: context.db).map(\.id)
 
     async let keystrokes = KeystrokeLine.query()
-      .where(.computerUserId |=| userDeviceIds)
+      .where(.computerUserId |=| computerUserIds)
       .where(.createdAt <= .date(before))
       .where(.createdAt > .date(after))
       .orderBy(.createdAt, .desc)
@@ -77,7 +78,7 @@ extension UserActivityFeed: Resolver {
       .all(in: context.db)
 
     async let screenshots = Screenshot.query()
-      .where(.computerUserId |=| userDeviceIds)
+      .where(.or(.computerUserId |=| computerUserIds, .iosDeviceId |=| iosDeviceIds))
       .where(.createdAt <= .date(before))
       .where(.createdAt > .date(after))
       .orderBy(.createdAt, .desc)
@@ -87,8 +88,8 @@ extension UserActivityFeed: Resolver {
     let coalesced = try await coalesce(screenshots, keystrokes)
 
     return Output(
-      userName: user.name,
-      showSuspensionActivity: user.showSuspensionActivity,
+      userName: child.name,
+      showSuspensionActivity: child.showSuspensionActivity,
       numDeleted: coalesced.lazy.filter(\.isDeleted).count,
       items: coalesced.lazy.filter(\.notDeleted)
     )

--- a/api/Sources/Api/PairQL/Dashboard/Pairs/UserActivitySummaries.swift
+++ b/api/Sources/Api/PairQL/Dashboard/Pairs/UserActivitySummaries.swift
@@ -34,7 +34,7 @@ extension UserActivitySummaries: Resolver {
     in context: AdminContext
   ) async throws -> Output {
     let user = try await context.verifiedUser(from: input.userId)
-    let userDeviceIds = try await user.devices(in: context.db).map(\.id)
+    let userDeviceIds = try await user.computerUsers(in: context.db).map(\.id)
     let days = try await UserActivitySummaries.days(
       dateRanges: input.dateRanges,
       userDeviceIds: userDeviceIds,

--- a/api/Sources/Api/Services/Jobs/SubscriptionManager.swift
+++ b/api/Sources/Api/Services/Jobs/SubscriptionManager.swift
@@ -175,7 +175,7 @@ private extension Admin {
   func completedOnboarding(_ db: any DuetSQL.Client) async throws -> Bool {
     let children = try await users(in: db)
     let childDevices = try await children.concurrentMap {
-      try await $0.devices(in: db)
+      try await $0.computerUsers(in: db)
     }.flatMap(\.self)
     return !childDevices.isEmpty
   }

--- a/api/Tests/ApiTests/ApiTests.swift
+++ b/api/Tests/ApiTests/ApiTests.swift
@@ -117,7 +117,7 @@ final class ApiTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testChildContextCreated() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     let response = try await PairQLRoute.respond(
       to: .macApp(.userAuthed(

--- a/api/Tests/ApiTests/DashboardPairResolvers/AuthedAdminResolverTests.swift
+++ b/api/Tests/ApiTests/DashboardPairResolvers/AuthedAdminResolverTests.swift
@@ -280,7 +280,7 @@ final class AuthedAdminResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testDeletingLastUserDeviceDeletesDevice() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     _ = try await DeleteEntity.resolve(
       with: .init(id: user.device.id.rawValue, type: .userDevice),
       in: context(user.admin)
@@ -290,7 +290,7 @@ final class AuthedAdminResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testDeletingUserDeletesOrphanedDevice() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     _ = try await DeleteEntity.resolve(
       with: .init(id: user.id.rawValue, type: .user),
       in: context(user.admin)
@@ -497,7 +497,7 @@ final class AuthedAdminResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testGetSuspendFilterRequest() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     var request = MacApp.SuspendFilterRequest.random
     request.computerUserId = user.device.id
     try await self.db.create(request)
@@ -515,7 +515,7 @@ final class AuthedAdminResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testGetUnlockRequests() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     var request = UnlockRequest.mock
     request.computerUserId = user.device.id

--- a/api/Tests/ApiTests/DashboardPairResolvers/DeviceResolversTests.swift
+++ b/api/Tests/ApiTests/DashboardPairResolvers/DeviceResolversTests.swift
@@ -62,7 +62,7 @@ final class DeviceResolversTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testSaveDevice() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     var device = user.adminDevice
     device.appReleaseChannel = .stable
     device.customName = nil

--- a/api/Tests/ApiTests/Entities.swift
+++ b/api/Tests/ApiTests/Entities.swift
@@ -139,25 +139,25 @@ extension ApiTestCase {
     return .init(model: child.model, device: iosDevice, token: token, parent: child.admin)
   }
 
-  func userWithDevice() async throws -> UserWithDeviceEntities {
-    let user = try await self.user()
-    let device = try await self.db.create(Device.random {
-      $0.parentId = user.admin.model.id
+  func childWithComputer() async throws -> UserWithDeviceEntities {
+    let child = try await self.user()
+    let computer = try await self.db.create(Device.random {
+      $0.parentId = child.admin.model.id
     })
-    let userDevice = try await self.db.create(UserDevice.random {
-      $0.childId = user.model.id
-      $0.computerId = device.id
+    let computerUser = try await self.db.create(UserDevice.random {
+      $0.childId = child.model.id
+      $0.computerId = computer.id
     })
     let token = try await self.db.create(UserToken(
-      childId: user.id,
-      computerUserId: userDevice.id
+      childId: child.id,
+      computerUserId: computerUser.id
     ))
     return .init(
-      model: user.model,
-      adminDevice: device,
-      device: userDevice,
+      model: child.model,
+      adminDevice: computer,
+      device: computerUser,
       token: token,
-      admin: user.admin
+      admin: child.admin
     )
   }
 }

--- a/api/Tests/ApiTests/MacappPairResolvers/CheckInNamedAppTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/CheckInNamedAppTests.swift
@@ -50,7 +50,7 @@ final class CheckInNameAppsTests: ApiTestCase, @unchecked Sendable {
   }
 
   func nameApps(_ namedApps: [RunningApp]) async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     _ = try await CheckIn_v2.resolve(
       with: .init(appVersion: "1.0.0", filterVersion: "3.3.3", namedApps: namedApps),
       in: user.context

--- a/api/Tests/ApiTests/MacappPairResolvers/CheckInResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/CheckInResolverTests.swift
@@ -111,7 +111,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
     id.identifiedAppId = app.id
     try await self.db.create(id)
 
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let output = try await CheckIn.resolve(
       with: .init(appVersion: "1.0.0", filterVersion: nil),
       in: user.context
@@ -120,7 +120,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testUserWithNoKeychainsDoesNotGetAutoIncluded_v1() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     try await self.createAutoIncludeKeychain()
 
     let output = try await CheckIn.resolve(
@@ -131,7 +131,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testUserWithAtLeastOneKeyGetsAutoIncluded_v1() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let admin = try await self.admin().withKeychain()
     try await self.db.create(UserKeychain(childId: user.id, keychainId: admin.keychain.id))
     let (_, autoKey) = try await createAutoIncludeKeychain()
@@ -144,7 +144,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testIncludesResolvedFilterSuspension_v1() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let susp = try await self.db.create(MacApp.SuspendFilterRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .accepted
@@ -179,7 +179,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testDoesNotIncludeUnresolvedSuspension_v1() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let susp = try await self.db.create(MacApp.SuspendFilterRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .pending // <-- still pending!
@@ -198,7 +198,7 @@ final class CheckInResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testIncludesResolvedUnlockRequests_v1() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let unlock1 = UnlockRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .pending // <-- pending, will not be returned

--- a/api/Tests/ApiTests/MacappPairResolvers/CheckIn_v2ResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/CheckIn_v2ResolverTests.swift
@@ -111,7 +111,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
     id.identifiedAppId = app.id
     try await self.db.create(id)
 
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let output = try await CheckIn_v2.resolve(
       with: .init(appVersion: "1.0.0", filterVersion: nil),
       in: user.context
@@ -120,7 +120,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testUserWithNoKeychainsDoesNotGetAutoIncluded() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     try await self.createAutoIncludeKeychain()
 
     let output = try await CheckIn_v2.resolve(
@@ -131,7 +131,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testUserWithAtLeastOneKeyGetsAutoIncluded() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let admin = try await self.admin().withKeychain()
     try await self.db.create(UserKeychain(childId: user.id, keychainId: admin.keychain.id))
     let (_, autoKey) = try await createAutoIncludeKeychain()
@@ -144,7 +144,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testIncludesResolvedFilterSuspension() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let susp = try await self.db.create(MacApp.SuspendFilterRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .accepted
@@ -179,7 +179,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testDoesNotIncludeUnresolvedSuspension() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let susp = try await self.db.create(MacApp.SuspendFilterRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .pending // <-- still pending!
@@ -198,7 +198,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testIncludesResolvedUnlockRequests() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let unlock1 = UnlockRequest.mock {
       $0.computerUserId = user.device.id
       $0.status = .pending // <-- pending, will not be returned

--- a/api/Tests/ApiTests/MacappPairResolvers/ConnectUserResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/ConnectUserResolverTests.swift
@@ -80,7 +80,7 @@ final class ConnectUserResolversTests: ApiTestCase, @unchecked Sendable {
     try await withDependencies {
       $0.date = .init { Date() } // for token expiration
     } operation: {
-      let existingUser = try await self.userWithDevice()
+      let existingUser = try await self.childWithComputer()
       let existingUserToken = try await self.db.create(UserToken(
         childId: existingUser.id,
         computerUserId: existingUser.device.id
@@ -114,7 +114,7 @@ final class ConnectUserResolversTests: ApiTestCase, @unchecked Sendable {
 
   // test sanity check, computer/user registered to a different admin
   func testConnectUser_ExistingDeviceToDifferentUser_FailsIfDifferentAdmin() async throws {
-    let existingUser = try await self.userWithDevice()
+    let existingUser = try await self.childWithComputer()
     let existingUserToken = try await self.db.create(UserToken(
       childId: existingUser.model.id,
       computerUserId: existingUser.device.id

--- a/api/Tests/ApiTests/MacappPairResolvers/CreateUnlockRequestsResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/CreateUnlockRequestsResolverTests.swift
@@ -7,7 +7,7 @@ import XExpect
 
 final class CreateUnlockRequestsResolverTests: ApiTestCase, @unchecked Sendable {
   func testCreateUnlockRequests_v3() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let blocked = CreateUnlockRequests_v3.Input.BlockedRequest(
       bundleId: "com.example.app",
       url: "https://example.com"

--- a/api/Tests/ApiTests/MacappPairResolvers/LogFilterEventsResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/LogFilterEventsResolverTests.swift
@@ -11,7 +11,7 @@ final class LogFilterEventsResolverTests: ApiTestCase, @unchecked Sendable {
     try await self.db.delete(all: IdentifiedApp.self)
     try await self.db.delete(all: UnidentifiedApp.self)
     try await self.db.create(UnidentifiedApp(bundleId: "com.widget", count: 3))
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let xcode = try await self.db
       .create(IdentifiedApp(name: "Xcode", slug: "", launchable: true))
     try await self.db.create(AppBundleId(identifiedAppId: xcode.id, bundleId: "com.xcode"))

--- a/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
+++ b/api/Tests/ApiTests/MacappPairResolvers/MacAppResolverTests.swift
@@ -9,7 +9,7 @@ import XExpect
 
 final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
   func testCreateSuspendFilterRequest() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     let id = try await CreateSuspendFilterRequest_v2.resolve(
       with: .init(duration: 1111, comment: "test"),
@@ -41,7 +41,7 @@ final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testOneFailedNotificationDoesntBlockRest() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     // admin gets two notifications on suspend filter request
     let slack = try await self.db.create(AdminVerifiedNotificationMethod(
@@ -83,7 +83,7 @@ final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testCreateKeystrokeLines() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     let (uuid, output) = try await withUUID {
       try await CreateKeystrokeLines.resolve(
@@ -105,7 +105,7 @@ final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testInsertKeystrokeLineWithNullByte() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     let (uuid, output) = try await withUUID {
       try await CreateKeystrokeLines.resolve(
@@ -126,7 +126,7 @@ final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testCreateSignedScreenshotUpload() async throws {
     let beforeCount = try await self.db.count(Screenshot.self)
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
 
     let output = try await withDependencies {
       $0.aws.signedS3UploadUrl = { _ in URL(string: "from-aws.com")! }
@@ -144,7 +144,7 @@ final class MacAppResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   func testCreateSignedScreenshotUploadWithDate() async throws {
-    let user = try await self.userWithDevice()
+    let user = try await self.childWithComputer()
     let uuids = MockUUIDs()
 
     try await withDependencies {


### PR DESCRIPTION
closes https://github.com/gertrude-app/project/issues/356.

this is a bit noisier than it maybe should be because i took the liberty to slowly rename a few more things (much easier now that the swift 6 LSP supports renaming) -- we changed a lot of our terminology a while back (user > child, device > computer, admin > parent, etc.) but the names in the database and codebase are only slowly catching up.

but basically this just alters the two queries for screenshots to also check for ios screenshots associated with a child, plus adds a test showing that they are resolved.