### PR TITLE
api: fix over-eager deletion of child activity

### DIFF
--- a/api/Sources/Api/Routes/Reset/Reset.swift
+++ b/api/Sources/Api/Routes/Reset/Reset.swift
@@ -115,9 +115,10 @@ enum Reset {
   ) -> Either<Screenshot, KeystrokeLine> {
     if [1, 2, 3].shuffled().first! != 1 {
       let (width, height) = [(800, 600), (900, 600), (800, 500), (900, 500)].shuffled().first!
+      let webAssetsUrl = "https://gertrude-web-assets.nyc3.digitaloceanspaces.com"
       return .left(Screenshot(
         computerUserId: userDeviceId,
-        url: "https://fakeimg.pl/\(width)x\(height)/3e2a73/ffffff",
+        url: "\(webAssetsUrl)/placeholders-imgs/\(width)x\(height).png",
         width: width,
         height: height
       ))

--- a/api/Sources/Api/Services/Jobs/DbCleanupJob.swift
+++ b/api/Sources/Api/Services/Jobs/DbCleanupJob.swift
@@ -27,7 +27,7 @@ struct CleanupJob: AsyncScheduledJob {
     let deletedScreenshots = try await Screenshot.query()
       .where(.and(
         .or(
-          .not(.isNull(.deletedAt)) .&& .deletedAt <= now,
+          .not(.isNull(.deletedAt)) .&& .deletedAt <= 14.daysAgo,
           .createdAt <= 21.daysAgo
         ),
         .or(.isNull(.flagged), .flagged <= 60.daysAgo)
@@ -39,7 +39,7 @@ struct CleanupJob: AsyncScheduledJob {
     let deletedKeystrokes = try await KeystrokeLine.query()
       .where(.and(
         .or(
-          .not(.isNull(.deletedAt)) .&& .deletedAt <= now,
+          .not(.isNull(.deletedAt)) .&& .deletedAt <= 14.daysAgo,
           .createdAt <= 21.daysAgo
         ),
         .or(.isNull(.flagged), .flagged <= 60.daysAgo)


### PR DESCRIPTION
the db cleanup job was too aggressive, purging deleted (aka "approved") child activity items before they were 14 days old. keeping them around for 14 days allows the parent to always see 2 weeks of their completed and uncompleted work.